### PR TITLE
Implement PUT mapping validation check

### DIFF
--- a/internal/controller/request/observe.go
+++ b/internal/controller/request/observe.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -61,6 +62,12 @@ func (c *external) isUpToDate(ctx context.Context, cr *v1alpha2.Request) (Observ
 	c.patchResponseToSecret(ctx, cr, &details.HttpResponse)
 	desiredState, err := c.desiredState(ctx, cr)
 	if err != nil {
+		if isErrorMappingNotFound(err) {
+			// Since there is no PUT mapping, we skip the check for its presence in the GET response.
+			return NewObserve(details, responseErr, true), nil
+		}
+
+		// For any other error, we return a failed observation.
 		return FailedObserve(), err
 	}
 
@@ -96,7 +103,11 @@ func (c *external) compareResponseAndDesiredState(details httpClient.HttpDetails
 
 func (c *external) desiredState(ctx context.Context, cr *v1alpha2.Request) (string, error) {
 	requestDetails, err := c.requestDetails(ctx, cr, http.MethodPut)
-	return requestDetails.Body.Encrypted.(string), err
+	if err != nil {
+		return "", err
+	}
+
+	return requestDetails.Body.Encrypted.(string), nil
 }
 
 func (c *external) requestDetails(ctx context.Context, cr *v1alpha2.Request, method string) (requestgen.RequestDetails, error) {
@@ -106,4 +117,10 @@ func (c *external) requestDetails(ctx context.Context, cr *v1alpha2.Request, met
 	}
 
 	return generateValidRequestDetails(ctx, c.localKube, cr, mapping)
+}
+
+// isErrorMappingNotFound checks if the provided error indicates that the
+// mapping for an HTTP PUT request is not found.
+func isErrorMappingNotFound(err error) bool {
+	return errors.Cause(err).Error() == fmt.Sprintf(errMappingNotFound, http.MethodPut)
 }


### PR DESCRIPTION
### Description
This PR adds a validation check to ensure that a `PUT` mapping exists before comparing the `PUT` body with the `GET` response. 
The comparison is performed to verify if the `PUT` body is contained within the `GET` response, ensuring that the resource is up to date. 
If the `PUT` mapping is not found, the comparison step is skipped, preventing potential errors. This enhancement improves the reliability and accuracy of resource provisioning.

Fixes #22 

### How has this code been tested
I have added a test case to cover this fix and ensured that all existing tests pass.