### PR TITLE
Fix: Enhance nested JSON comparison in Contains function

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.2)"
+        description: "Release version (e.g. v1.0.3)"
         required: true
       channel:
         description: "Release channel"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.2)"
+        description: "Release version (e.g. v1.0.3)"
         required: true
       message:
         description: "Tag message"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install `provider-http`, you have two options:
 1. Using the Crossplane CLI in a Kubernetes cluster where Crossplane is installed:
 
    ```console
-   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.2
+   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.3
    ```
 
 2. Manually creating a Provider by applying the following YAML:
@@ -20,7 +20,7 @@ To install `provider-http`, you have two options:
    metadata:
      name: provider-http
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.2"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.3"
    ```
 
 ## Supported Resources

--- a/deploy.yml
+++ b/deploy.yml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: http-provider
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.2
+  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.3
   controllerConfigRef:
     name: debug-config
 

--- a/examples/sample/request.yaml
+++ b/examples/sample/request.yaml
@@ -4,6 +4,7 @@ metadata:
   name: laundry
 spec:
   forProvider:
+    # Injecting data from secrets is possible, simply use the following syntax: {{ name:namespace:key }} (supported for body and headers only)
     insecureSkipTLSVerify: true
     waitTimeout: 5m
     headers:

--- a/internal/json/util.go
+++ b/internal/json/util.go
@@ -5,30 +5,44 @@ import (
 	"encoding/json"
 )
 
+// Contains checks if the containee map is contained within the container map, including nested JSON structures.
 func Contains(container, containee map[string]interface{}) bool {
 	for key, value := range containee {
-		if containerValue, exists := container[key]; !exists || !deepEqual(value, containerValue) {
+		containerValue, exists := container[key]
+		if !exists {
+			return false
+		}
+		if nestedMap, ok := value.(map[string]interface{}); ok {
+			if containerNestedMap, ok := containerValue.(map[string]interface{}); ok {
+				if !Contains(containerNestedMap, nestedMap) {
+					return false
+				}
+			} else {
+				return false
+			}
+		} else if !deepEqual(value, containerValue) {
 			return false
 		}
 	}
 	return true
 }
 
+// IsJSONString checks if a given string is a valid JSON.
 func IsJSONString(jsonStr string) bool {
 	var js map[string]interface{}
 	return json.Unmarshal([]byte(jsonStr), &js) == nil
 }
 
+// JsonStringToMap converts a JSON string to a map.
 func JsonStringToMap(jsonStr string) map[string]interface{} {
 	var jsonData map[string]interface{}
 	_ = json.Unmarshal([]byte(jsonStr), &jsonData)
 	return jsonData
 }
 
-// Converts JSON strings within a map to maps for JSON data processing.
+// ConvertJSONStringsToMaps converts JSON strings within a map to maps for JSON data processing.
 func ConvertJSONStringsToMaps(merged *map[string]interface{}) {
 	for key, value := range *merged {
-
 		switch valueToHandle := value.(type) {
 		case string:
 			if IsJSONString(valueToHandle) {
@@ -38,42 +52,40 @@ func ConvertJSONStringsToMaps(merged *map[string]interface{}) {
 		case map[string]interface{}:
 			ConvertJSONStringsToMaps(&valueToHandle)
 		case []interface{}:
-			structToMap, _ := (StructToMap(valueToHandle))
+			structToMap, _ := StructToMap(valueToHandle)
 			ConvertJSONStringsToMaps(&structToMap)
 		}
 	}
 }
 
+// StructToMap converts a struct to a map.
 func StructToMap(obj interface{}) (newMap map[string]interface{}, err error) {
-	data, err := json.Marshal(obj) // Convert to a json string
-
+	data, err := json.Marshal(obj) // Convert to a JSON string
 	if err != nil {
 		return
 	}
-
 	err = json.Unmarshal(data, &newMap) // Convert to a map
 	return
 }
 
+// ConvertMapToJson converts a map to a JSON byte slice.
 func ConvertMapToJson(m map[string]interface{}) ([]byte, bool) {
 	jsonData, err := json.Marshal(m)
 	if err != nil {
 		return nil, false
 	}
-
 	return jsonData, true
 }
 
+// deepEqual checks if two interfaces are deeply equal by comparing their JSON representations.
 func deepEqual(a, b interface{}) bool {
 	aBytes, err := json.Marshal(a)
 	if err != nil {
 		return false
 	}
-
 	bBytes, err := json.Marshal(b)
 	if err != nil {
 		return false
 	}
-
 	return bytes.Equal(aBytes, bBytes)
 }

--- a/internal/json/util_test.go
+++ b/internal/json/util_test.go
@@ -62,7 +62,7 @@ func Test_Contains(t *testing.T) {
 	}{
 		"Success": {
 			args: args{
-				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe"},
+				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe", "details": map[string]any{"a": "a", "b": "b"}},
 				containee: map[string]any{"username": "john_doe"},
 			},
 			want: want{
@@ -71,8 +71,17 @@ func Test_Contains(t *testing.T) {
 		},
 		"SuccessMatchesJsons": {
 			args: args{
-				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe"},
-				containee: map[string]any{"email": "john.doe@example.com", "username": "john_doe"},
+				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe", "details": map[string]any{"a": "a", "b": map[string]any{"c": "c", "a": "a"}}},
+				containee: map[string]any{"email": "john.doe@example.com", "username": "john_doe", "details": map[string]any{"a": "a", "b": map[string]any{"c": "c", "a": "a"}}},
+			},
+			want: want{
+				result: true,
+			},
+		},
+		"SuccessNestedJsons": {
+			args: args{
+				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe", "details": map[string]any{"a": "a", "b": "b", "c": map[string]any{"c": "c", "a": "a"}}},
+				containee: map[string]any{"email": "john.doe@example.com", "username": "john_doe", "details": map[string]any{"b": "b", "c": map[string]any{"c": "c"}}},
 			},
 			want: want{
 				result: true,
@@ -82,6 +91,42 @@ func Test_Contains(t *testing.T) {
 			args: args{
 				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe"},
 				containee: map[string]any{"false": "false.false@example.com"},
+			},
+			want: want{
+				result: false,
+			},
+		},
+		"NestedJsonsFail": {
+			args: args{
+				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe", "details": map[string]any{"a": "a", "b": "b"}},
+				containee: map[string]any{"email": "john.doe@example.com", "username": "john_doe", "details": map[string]any{"a": "a", "c": "c"}},
+			},
+			want: want{
+				result: false,
+			},
+		},
+		"ExtraKeysInContainer": {
+			args: args{
+				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe", "extra": "extra_value"},
+				containee: map[string]any{"email": "john.doe@example.com"},
+			},
+			want: want{
+				result: true,
+			},
+		},
+		"EmptyContainee": {
+			args: args{
+				container: map[string]any{"email": "john.doe@example.com", "username": "john_doe"},
+				containee: map[string]any{},
+			},
+			want: want{
+				result: true,
+			},
+		},
+		"EmptyContainer": {
+			args: args{
+				container: map[string]any{},
+				containee: map[string]any{"email": "john.doe@example.com"},
 			},
 			want: want{
 				result: false,

--- a/resources-docs/request_docs.md
+++ b/resources-docs/request_docs.md
@@ -47,7 +47,10 @@ Here is an example `Request` resource definition:
 - headers: Default HTTP request headers.
 - payload: Customizable values for HTTP requests, with jq query support [jq Documentation](https://jqlang.github.io/jq/manual/#object-identifier-index).
 - mappings: List of mappings, each specifying the HTTP method, URL, and optional request body.
+-  secretInjectionConfigs: Optional Configurations for secrets receiving patches from response data.
 
+### Secrets Injection
+The DisposableRequest resource supports injecting data from secrets into the request's body and headers using the following syntax: {{ name:namespace:key }} (supported for body and headers only).
 
 ## PUT Mapping - Desired State
 The PUT mapping represents your desired state. The body in this mapping should be contained in the GET response. If it's not, a PUT request will be sent with the according body.


### PR DESCRIPTION
### Description
This PR addresses an issue where the provider's `Contains` function did not properly handle nested JSON structures. The updated logic ensures that nested maps within the `PUT` body are correctly compared with those in the `GET` response.

### Changes
- Enhanced the `Contains` function to handle nested maps recursively.

### Testing
- Verified the changes with test cases involving nested JSON structures.
- Ensured that the modified `Contains` function correctly identifies if the `PUT` body is contained within the `GET` response.

### Impact
- This change improves the accuracy of state comparison for resources with nested JSON structures.
- The provider now more reliably maintains the desired state by accurately tracking resource modifications.

### Notes
- Future considerations may include making this comparison behavior more configurable based on user feedback.

Closes #27 