### PR TITLE
feat: implement owner reference for secrets

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.3)"
+        description: "Release version (e.g. v1.0.4)"
         required: true
       channel:
         description: "Release channel"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.3)"
+        description: "Release version (e.g. v1.0.4)"
         required: true
       message:
         description: "Tag message"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install `provider-http`, you have two options:
 1. Using the Crossplane CLI in a Kubernetes cluster where Crossplane is installed:
 
    ```console
-   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.3
+   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.4
    ```
 
 2. Manually creating a Provider by applying the following YAML:
@@ -20,7 +20,7 @@ To install `provider-http`, you have two options:
    metadata:
      name: provider-http
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.3"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.4"
    ```
 
 ## Supported Resources

--- a/apis/disposablerequest/v1alpha2/disposablerequest_types.go
+++ b/apis/disposablerequest/v1alpha2/disposablerequest_types.go
@@ -76,6 +76,9 @@ type SecretInjectionConfig struct {
 
 	// ResponsePath is is a jq filter expression represents the path in the response where the secret value will be extracted from.
 	ResponsePath string `json:"responsePath"`
+
+	// SetOwnerReference determines whether to set the owner reference on the Kubernetes secret.
+	SetOwnerReference bool `json:"setOwnerReference,omitempty"`
 }
 
 // SecretRef contains the name and namespace of a Kubernetes secret.

--- a/apis/request/v1alpha2/request_types.go
+++ b/apis/request/v1alpha2/request_types.go
@@ -75,6 +75,9 @@ type SecretInjectionConfig struct {
 
 	// ResponsePath is is a jq filter expression represents the path in the response where the secret value will be extracted from.
 	ResponsePath string `json:"responsePath"`
+
+	// SetOwnerReference determines whether to set the owner reference on the Kubernetes secret.
+	SetOwnerReference bool `json:"setOwnerReference,omitempty"`
 }
 
 // SecretRef contains the name and namespace of a Kubernetes secret.

--- a/cluster/test/setup.sh
+++ b/cluster/test/setup.sh
@@ -20,39 +20,39 @@ cat <<EOF | ${KUBECTL} apply -f -
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: todo
+  name: flask-api
+  namespace: default
   labels:
-    app: todo
+    app: flask-api
 spec:
-  replicas: 1 
+  replicas: 3
   selector:
     matchLabels:
-      app: todo
+      app: flask-api
   template:
     metadata:
       labels:
-        app: todo
+        app: flask-api
     spec:
       containers:
-      - name: todo
-        image: danielsinai/todo:v1.0.0
-        env:
-        - name: PORT
-          value: "80"
+      - name: flask-api
+        image: arielsepton/flask-api:latest
         ports:
-        - containerPort: 80
+        - containerPort: 5000
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: todo
+  name: flask-api
+  namespace: default
 spec:
-  type: ClusterIP
-  ports:
-  - name: "todo"
-    port: 80
   selector:
-    app: todo
+    app: flask-api
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 5000
+  type: ClusterIP
 EOF
 
 cat <<EOF | kubectl apply -f -
@@ -70,9 +70,20 @@ cat <<EOF | kubectl apply -f -
 kind: Secret
 apiVersion: v1
 metadata:
-  name: password
+  name: user-password
   namespace: crossplane-system
 type: Opaque
 data:
-  secretKey: bXktc2VjcmV0LXZhbHVl
+  password: bXktc2VjcmV0LXZhbHVl
+EOF
+
+cat <<EOF | kubectl apply -f -
+kind: Secret
+apiVersion: v1
+metadata:
+  name: basic-auth
+  namespace: crossplane-system
+type: Opaque
+data:
+  token: bXktc2VjcmV0LXZhbHVl
 EOF

--- a/deploy.yml
+++ b/deploy.yml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: http-provider
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.3
+  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.4
   controllerConfigRef:
     name: debug-config
 

--- a/examples/sample/disposablerequest.yaml
+++ b/examples/sample/disposablerequest.yaml
@@ -1,28 +1,28 @@
 apiVersion: http.crossplane.io/v1alpha2
 kind: DisposableRequest
 metadata:
-  name: health-check
+  name: send-notification
 spec:
   deletionPolicy: Orphan
   forProvider:
     # Injecting data from secrets is possible, simply use the following syntax: {{ name:namespace:key }} (supported for body and headers only)
-    url:  http://todo.default.svc.cluster.local/health-check
+    url:  http://flask-api.default.svc.cluster.local/v1/notify
     method: POST
     body: |
       {
-        "check_type": "simple",
-        "additional_info": "optional",
-        "password": "secretdata {{ password:crossplane-system:secretKey }}"
+        "recipient": "user@example.com",
+        "subject": "Alert",
+        "message": "Your action is required immediately."
       }
     headers:
-      User-Agent:
-        - "Crossplane Health Checker"
+      Content-Type:
+        - application/json
       Authorization:
         - "Bearer {{ auth:default:token }}"
     insecureSkipTLSVerify: true
 
     # The 'expectedResponse' field is optional. If used, also set 'rollbackRetriesLimit', which determines the number of HTTP requests to be sent until the jq query returns true.
-    # expectedResponse: '.body.job_status == "success"'
+    expectedResponse: '.body.status == "sent"'
     rollbackRetriesLimit: 5
     waitTimeout: 5m
 
@@ -35,15 +35,19 @@ spec:
     # Secrets receiving patches from response data
     secretInjectionConfigs: 
       - secretRef:
-          name: response-secret
+          name: notification-response
           namespace: default
-        secretKey: extracted-data
-        responsePath: .body.reminder
+        secretKey: notification-status
+        responsePath: .body.status
+        # setOwnerReference determines if the secret should be deleted when the associated resource is deleted.
+        # When injecting multiple keys into the same secret, ensure this field is set consistently for all keys.        
+        setOwnerReference: true
       - secretRef:
-          name: response-secret
+          name: notification-response
           namespace: default
-        secretKey: extracted-data-headers
-        responsePath: .headers.Try[0]
+        secretKey: notification-id
+        responsePath: .body.id
+        setOwnerReference: true
   providerConfigRef:
     name: http-conf
 # TODO: check if it's possible to modify the deletionPolicy to be orphan by default.

--- a/examples/sample/disposablerequest_jwt.yaml
+++ b/examples/sample/disposablerequest_jwt.yaml
@@ -1,0 +1,40 @@
+apiVersion: http.crossplane.io/v1alpha2
+kind: DisposableRequest
+metadata:
+  name: obtain-jwt-token
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    insecureSkipTLSVerify: true
+
+    # Injecting data from secrets is possible, simply use the following syntax: {{ name:namespace:key }} (supported for body and headers only)
+    headers:
+      Authorization:
+        - "Basic {{ basic-auth:crossplane-system:token }}"
+    url:  http://flask-api.default.svc.cluster.local/v1/login
+    method: POST
+    
+    shouldLoopInfinitely: true
+    nextReconcile: 72h # 3 days
+
+    # waitTimeout: 5m
+
+    # Indicates whether the reconciliation should loop indefinitely. If `rollbackRetriesLimit` is set and the request returns an error, it will stop reconciliation once the limit is reached.
+    # shouldLoopInfinitely: true
+
+    # Specifies the duration after which the next reconcile should occur.
+    # nextReconcile: 3m 
+
+    # Secrets receiving patches from response data
+    secretInjectionConfigs: 
+      - secretRef:
+          name: obtained-token
+          namespace: crossplane-system
+        secretKey: token
+        responsePath: .body.token
+        # setOwnerReference determines if the secret should be deleted when the associated resource is deleted.
+        # When injecting multiple keys into the same secret, ensure this field is set consistently for all keys.        
+        setOwnerReference: true
+  providerConfigRef:
+    name: http-conf
+# TODO: check if it's possible to modify the deletionPolicy to be orphan by default.

--- a/examples/sample/request.yaml
+++ b/examples/sample/request.yaml
@@ -1,7 +1,7 @@
 apiVersion: http.crossplane.io/v1alpha2
 kind: Request
 metadata:
-  name: laundry
+  name: manage-user
 spec:
   forProvider:
     # Injecting data from secrets is possible, simply use the following syntax: {{ name:namespace:key }} (supported for body and headers only)
@@ -13,21 +13,22 @@ spec:
       Authorization:
         - ("Bearer {{ auth:default:token }}")
     payload:
-      baseUrl: http://todo.default.svc.cluster.local/todos
+      baseUrl: http://flask-api.default.svc.cluster.local/v1/users
       body: |
         {
-          "name": "Do Laundry", 
-          "reminder": "Every 1 hour", 
-          "responsible": "Dan",
-          "password": "secretdata {{ password:crossplane-system:secretKey }}"
+          "username": "mock_user", 
+          "password": "secretdata {{ user-password:crossplane-system:password }}",
+          "email": "mock_user@example.com", 
+          "age": 30
         }
     mappings:
       - method: "POST"
         body: |
           {
-            todo_name: .payload.body.name, 
-            reminder: .payload.body.reminder, 
-            responsible: .payload.body.responsible,
+            username: .payload.body.username, 
+            email: .payload.body.email, 
+            age: .payload.body.age,
+            password: .payload.body.password
           }
         url: .payload.baseUrl
         headers:
@@ -42,9 +43,8 @@ spec:
       - method: "PUT"
         body: |
           {
-            todo_name: .payload.body.name, 
-            reminder: .payload.body.reminder, 
-            responsible: .payload.body.responsible
+            email: .payload.body.email, 
+            age: .payload.body.age
           }
         url: (.payload.baseUrl + "/" + (.response.body.id|tostring))
       - method: "DELETE"
@@ -55,12 +55,21 @@ spec:
       - secretRef:
           name: response-secret
           namespace: default
-        secretKey: extracted-data
-        responsePath: .body.reminder
+        secretKey: extracted-user-email
+        responsePath: .body.email
+        # setOwnerReference determines if the secret should be deleted when the associated resource is deleted.
+        # When injecting multiple keys into the same secret, ensure this field is set consistently for all keys.        
+        setOwnerReference: true
       - secretRef:
           name: response-secret
           namespace: default
-        secretKey: extracted-data-headers
-        responsePath: .headers.Try[0]
+        secretKey: extracted-header-data
+        responsePath: .headers."X-Secret-Header"[0]
+        setOwnerReference: true
+      - secretRef:
+          name: response-user-password
+          namespace: default
+        secretKey: extracted-user-password
+        responsePath: .body.password
   providerConfigRef:
     name: http-conf

--- a/internal/controller/request/observe.go
+++ b/internal/controller/request/observe.go
@@ -116,7 +116,7 @@ func (c *external) requestDetails(ctx context.Context, cr *v1alpha2.Request, met
 		return requestgen.RequestDetails{}, errors.Errorf(errMappingNotFound, method)
 	}
 
-	return generateValidRequestDetails(ctx, c.localKube, cr, mapping)
+	return c.generateValidRequestDetails(ctx, cr, mapping)
 }
 
 // isErrorMappingNotFound checks if the provided error indicates that the

--- a/internal/controller/request/requestgen/request_generator_test.go
+++ b/internal/controller/request/requestgen/request_generator_test.go
@@ -189,7 +189,7 @@ func Test_GenerateRequestDetails(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, gotErr, ok := GenerateRequestDetails(context.Background(), tc.args.localKube, tc.args.methodMapping, tc.args.forProvider, tc.args.response)
+			got, gotErr, ok := GenerateRequestDetails(context.Background(), tc.args.localKube, tc.args.methodMapping, tc.args.forProvider, tc.args.response, tc.args.logger)
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
 				t.Fatalf("GenerateRequestDetails(...): -want error, +got error: %s", diff)
 			}

--- a/internal/controller/request/statushandler/status.go
+++ b/internal/controller/request/statushandler/status.go
@@ -99,7 +99,7 @@ func (r *requestStatusHandler) appendExtraSetters(forProvider v1alpha2.RequestPa
 func (r *requestStatusHandler) shouldSetCache(forProvider v1alpha2.RequestParameters) bool {
 	for _, mapping := range forProvider.Mappings {
 		response := responseconverter.HttpResponseToV1alpha1Response(r.resource.HttpResponse)
-		requestDetails, _, ok := requestgen.GenerateRequestDetails(r.resource.RequestContext, r.resource.LocalClient, mapping, forProvider, response)
+		requestDetails, _, ok := requestgen.GenerateRequestDetails(r.resource.RequestContext, r.resource.LocalClient, mapping, forProvider, response, r.logger)
 		if !(requestgen.IsRequestValid(requestDetails) && ok) {
 			return false
 		}

--- a/internal/data-patcher/parser.go
+++ b/internal/data-patcher/parser.go
@@ -23,6 +23,7 @@ import (
 const (
 	errEmptyKey    = "Warning, value at field %s is empty, skipping secret update for: %s"
 	errConvertData = "failed to convert data to map"
+	errPatchFailed = "failed to patch secret, %s"
 )
 
 const (
@@ -69,7 +70,7 @@ func replacePlaceholderWithSecretValue(originalString, old string, secret *corev
 }
 
 // patchSecretsToValue patches secrets referenced in the provided value.
-func patchSecretsToValue(ctx context.Context, localKube client.Client, valueToHandle string) (string, error) {
+func patchSecretsToValue(ctx context.Context, localKube client.Client, valueToHandle string, logger logging.Logger) (string, error) {
 	placeholders := removeDuplicates(findPlaceholders(valueToHandle))
 	for _, placeholder := range placeholders {
 
@@ -79,6 +80,7 @@ func patchSecretsToValue(ctx context.Context, localKube client.Client, valueToHa
 		}
 		secret, err := kubehandler.GetSecret(ctx, localKube, name, namespace)
 		if err != nil {
+			logger.Info(fmt.Sprintf(errPatchFailed, err.Error()))
 			return "", err
 		}
 

--- a/internal/data-patcher/parser_test.go
+++ b/internal/data-patcher/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -294,7 +295,7 @@ func Test_patchSecretsToValue(t *testing.T) {
 		tc := tc // Create local copies of loop variables
 
 		t.Run(name, func(t *testing.T) {
-			got, err := patchSecretsToValue(context.Background(), tc.args.localKube, tc.args.valueToHandle)
+			got, err := patchSecretsToValue(context.Background(), tc.args.localKube, tc.args.valueToHandle, logging.NewNopLogger())
 			if err != nil {
 				t.Fatalf("patchSecretsToValue(...): unexpected error: %v", err)
 			}

--- a/internal/data-patcher/patch_test.go
+++ b/internal/data-patcher/patch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -75,7 +76,7 @@ func TestPatchSecretsIntoBody(t *testing.T) {
 		tc := tc // Create local copies of loop variables
 
 		t.Run(name, func(t *testing.T) {
-			got, gotErr := PatchSecretsIntoBody(tc.args.ctx, tc.args.localKube, tc.args.body)
+			got, gotErr := PatchSecretsIntoBody(tc.args.ctx, tc.args.localKube, tc.args.body, logging.NewNopLogger())
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
 				t.Fatalf("isUpToDate(...): -want error, +got error: %s", diff)
 			}
@@ -184,7 +185,7 @@ func TestPatchSecretsIntoHeaders(t *testing.T) {
 		tc := tc // Create local copies of loop variables
 
 		t.Run(name, func(t *testing.T) {
-			got, gotErr := PatchSecretsIntoHeaders(tc.args.ctx, tc.args.localKube, tc.args.headers)
+			got, gotErr := PatchSecretsIntoHeaders(tc.args.ctx, tc.args.localKube, tc.args.headers, logging.NewNopLogger())
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
 				t.Fatalf("isUpToDate(...): -want error, +got error: %s", diff)
 			}

--- a/internal/kube-handler/client.go
+++ b/internal/kube-handler/client.go
@@ -2,6 +2,7 @@ package kubehandler
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -9,12 +10,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
-	errCreateSecret = "create secret failed"
-	errGetSecret    = "get secret failed"
-	errUpdateFailed = "update secret failed"
+	errCreateSecret      = "create secret failed"
+	errGetSecret         = "failed to get secret %s:%s"
+	errUpdateFailed      = "update secret failed"
+	errSetOwnerReference = "could not set owner reference to secret"
 )
 
 // GetSecret retrieves a Kubernetes Secret from the cluster.
@@ -26,21 +29,31 @@ func GetSecret(ctx context.Context, kubeClient client.Client, name string, names
 	}, secret)
 
 	if err != nil {
-		return &corev1.Secret{}, errors.Wrap(err, errGetSecret)
+		return nil, errors.Wrap(err, fmt.Sprintf(errGetSecret, name, namespace))
 	}
 
 	return secret, nil
 }
 
 // GetOrCreateSecret retrieves a Kubernetes Secret from the cluster. If the secret does not exist, it creates a new one.
-func GetOrCreateSecret(ctx context.Context, kubeClient client.Client, name string, namespace string) (*corev1.Secret, error) {
+// If the secret exists but has no owner reference, it sets the owner reference and updates the secret.
+func GetOrCreateSecret(ctx context.Context, kubeClient client.Client, name, namespace string, owner metav1.Object) (*corev1.Secret, error) {
 	secret, err := GetSecret(ctx, kubeClient, name, namespace)
 	if err != nil {
 		if errs.IsNotFound(err) {
-			return createSecret(ctx, kubeClient, name, namespace)
+			return createSecret(ctx, kubeClient, name, namespace, owner)
 		}
+		return nil, err
+	}
 
-		return &corev1.Secret{}, err
+	// Check if the owner reference is missing and set it if needed
+	if owner != nil && !hasOwnerReference(secret, owner) {
+		if err := controllerutil.SetOwnerReference(owner, secret, kubeClient.Scheme()); err != nil {
+			return nil, errors.Wrap(err, errSetOwnerReference)
+		}
+		if err := UpdateSecret(ctx, kubeClient, secret); err != nil {
+			return nil, err
+		}
 	}
 
 	return secret, nil
@@ -56,7 +69,8 @@ func UpdateSecret(ctx context.Context, kubeClient client.Client, secret *corev1.
 	return nil
 }
 
-func createSecret(ctx context.Context, kubeClient client.Client, name string, namespace string) (*corev1.Secret, error) {
+// createSecret creates a new Kubernetes Secret in the cluster.
+func createSecret(ctx context.Context, kubeClient client.Client, name, namespace string, owner metav1.Object) (*corev1.Secret, error) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -64,10 +78,26 @@ func createSecret(ctx context.Context, kubeClient client.Client, name string, na
 		},
 	}
 
+	if owner != nil {
+		if err := controllerutil.SetOwnerReference(owner, secret, kubeClient.Scheme()); err != nil {
+			return nil, errors.Wrap(err, errSetOwnerReference)
+		}
+	}
+
 	err := kubeClient.Create(ctx, secret)
 	if err != nil {
-		return &corev1.Secret{}, errors.Wrap(err, errCreateSecret)
+		return nil, errors.Wrap(err, errCreateSecret)
 	}
 
 	return secret, nil
+}
+
+// hasOwnerReference checks if the given secret has the specified owner reference.
+func hasOwnerReference(secret *corev1.Secret, owner metav1.Object) bool {
+	for _, ref := range secret.OwnerReferences {
+		if ref.UID == owner.GetUID() {
+			return true
+		}
+	}
+	return false
 }

--- a/package/crds/http.crossplane.io_disposablerequests.yaml
+++ b/package/crds/http.crossplane.io_disposablerequests.yaml
@@ -514,6 +514,10 @@ spec:
                           - name
                           - namespace
                           type: object
+                        setOwnerReference:
+                          description: SetOwnerReference determines whether to set
+                            the owner reference on the Kubernetes secret.
+                          type: boolean
                       required:
                       - responsePath
                       - secretKey

--- a/package/crds/http.crossplane.io_requests.yaml
+++ b/package/crds/http.crossplane.io_requests.yaml
@@ -546,6 +546,10 @@ spec:
                           - name
                           - namespace
                           type: object
+                        setOwnerReference:
+                          description: SetOwnerReference determines whether to set
+                            the owner reference on the Kubernetes secret.
+                          type: boolean
                       required:
                       - responsePath
                       - secretKey


### PR DESCRIPTION
## Implementing `SetOwnerReference` for Secrets Receiving Patches from Response Data

### Description
This PR introduces the `setOwnerReference` feature for secrets receiving patches from response data in the `secretInjectionConfigs` section. This enhancement ensures that secrets can be automatically deleted when the associated resource is deleted, providing better resource management and cleanup in Kubernetes.
### Changes
* New Configuration Option: setOwnerReference
  * Added a new field `setOwnerReference` in the `secretInjectionConfigs` section.
  * When `setOwnerReference` is set to true, the secret will have its owner reference set to the associated resource, ensuring the secret is deleted if the resource is deleted.
### Testing
Ran the existing tests, and added tests for the new feature.

Closes #40 