### PR TITLE
feat: improve observation validation for POST requests

### DIFF
--- a/examples/sample/disposablerequest-jwt.yaml
+++ b/examples/sample/disposablerequest-jwt.yaml
@@ -14,16 +14,12 @@ spec:
     url:  http://flask-api.default.svc.cluster.local/v1/login
     method: POST
     
+    # Indicates whether the reconciliation should loop indefinitely. If `rollbackRetriesLimit` is set and the request returns an error, it will stop reconciliation once the limit is reached.
     shouldLoopInfinitely: true
+    # Specifies the duration after which the next reconcile should occur.
     nextReconcile: 72h # 3 days
 
     # waitTimeout: 5m
-
-    # Indicates whether the reconciliation should loop indefinitely. If `rollbackRetriesLimit` is set and the request returns an error, it will stop reconciliation once the limit is reached.
-    # shouldLoopInfinitely: true
-
-    # Specifies the duration after which the next reconcile should occur.
-    # nextReconcile: 3m 
 
     # Secrets receiving patches from response data
     secretInjectionConfigs: 

--- a/examples/sample/request.yaml
+++ b/examples/sample/request.yaml
@@ -61,7 +61,7 @@ spec:
         url: (.payload.baseUrl + "/" + (.response.body.id|tostring))
     
     # expectedResponseCheck is optional. If not specified or if the type is "DEFAULT", 
-    # the resource is considered up to date if the GET response matches the PUT body.
+    # the resource is considered up to date if the GET response containes the PUT body.
     # If specified, the JQ logic determines if the resource is up to date:
     # - If the JQ query is false, a PUT request is sent to update the resource.
     # - If true, the resource is considered up to date.

--- a/internal/clients/http/client.go
+++ b/internal/clients/http/client.go
@@ -54,7 +54,11 @@ type HttpDetails struct {
 // SendRequest sends an HTTP request to the specified URL with the given method, body, headers and skipTLSVerify.
 func (hc *client) SendRequest(ctx context.Context, method string, url string, body Data, headers Data, skipTLSVerify bool) (details HttpDetails, err error) {
 	requestBody := []byte(body.Decrypted.(string))
+
+	// request contains the HTTP request that will be sent.
 	request, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(requestBody))
+
+	// requestDetails contains the request details that will be logged.
 	requestDetails := HttpRequest{
 		URL:     url,
 		Body:    body.Encrypted.(string),

--- a/internal/controller/request/observe.go
+++ b/internal/controller/request/observe.go
@@ -81,7 +81,7 @@ func (c *external) determineResponseCheck(ctx context.Context, cr *v1alpha2.Requ
 
 // isObjectValidForObservation checks if the object is valid for observation
 func (c *external) isObjectValidForObservation(cr *v1alpha2.Request) bool {
-	return cr.Status.Response.Body != "" &&
+	return cr.Status.Response.StatusCode != 0 &&
 		!(cr.Status.RequestDetails.Method == http.MethodPost && utils.IsHTTPError(cr.Status.Response.StatusCode))
 }
 

--- a/internal/utils/retry.go
+++ b/internal/utils/retry.go
@@ -10,18 +10,22 @@ const (
 	defaultWaitTimeout = 5 * time.Minute
 )
 
+// ShouldRetry determines if the request should be retried based on the status of the request and the rollback retries limit.
 func ShouldRetry(rollbackRetriesLimit *int32, statusFailed int32) bool {
 	return RollBackEnabled(rollbackRetriesLimit) && statusFailed != 0
 }
 
+// RollBackEnabled determines if the rollback retries limit is enabled.
 func RollBackEnabled(rollbackRetriesLimit *int32) bool {
 	return rollbackRetriesLimit != nil
 }
 
+// RetriesLimitReached determines if the rollback retries limit has been reached.
 func RetriesLimitReached(statusFailed int32, rollbackRetriesLimit *int32) bool {
 	return statusFailed >= *rollbackRetriesLimit
 }
 
+// WaitTimeout returns the wait timeout duration.
 func WaitTimeout(timeout *v1.Duration) time.Duration {
 	if timeout != nil {
 		return timeout.Duration
@@ -29,6 +33,7 @@ func WaitTimeout(timeout *v1.Duration) time.Duration {
 	return defaultWaitTimeout
 }
 
+// GetRollbackRetriesLimit returns the rollback retries limit.
 func GetRollbackRetriesLimit(rollbackRetriesLimit *int32) int32 {
 	limit := int32(1)
 	if rollbackRetriesLimit != nil {

--- a/internal/utils/set_status.go
+++ b/internal/utils/set_status.go
@@ -11,8 +11,10 @@ const (
 	ErrFailedToSetStatus = "failed to update status"
 )
 
+// SetRequestStatusFunc is a function that sets the status of a resource.
 type SetRequestStatusFunc func()
 
+// RequestResource is a struct that holds the resource, request context, http response, http request, and local client.
 type RequestResource struct {
 	Resource       client.Object
 	RequestContext context.Context
@@ -101,36 +103,44 @@ func (rr *RequestResource) ResetFailures() SetRequestStatusFunc {
 	}
 }
 
+// ResponseSetter is an interface that defines the methods to set the status code, headers, and body of a resource.
 type ResponseSetter interface {
 	SetStatusCode(statusCode int)
 	SetHeaders(headers map[string][]string)
 	SetBody(body string)
 }
 
+// CacheSetter is an interface that defines the method to set the cache of a resource.
 type CacheSetter interface {
 	SetCache(statusCode int, headers map[string][]string, body string)
 }
 
+// SyncedSetter is an interface that defines the method to set the synced status of a resource.
 type SyncedSetter interface {
 	SetSynced(synced bool)
 }
 
+// ErrorSetter is an interface that defines the method to set the error of a resource.
 type ErrorSetter interface {
 	SetError(err error)
 }
 
+// ResetFailures is an interface that defines the method to reset the failures of a resource.
 type ResetFailures interface {
 	ResetFailures()
 }
 
+// LastReconcileTimeSetter is an interface that defines the method to set the last reconcile time of a resource.
 type LastReconcileTimeSetter interface {
 	SetLastReconcileTime()
 }
 
+// RequestDetailsSetter is an interface that defines the method to set the request details of a resource.
 type RequestDetailsSetter interface {
 	SetRequestDetails(url, method, body string, headers map[string][]string)
 }
 
+// SetRequestResourceStatus sets the status of a resource.
 func SetRequestResourceStatus(rr RequestResource, statusFuncs ...SetRequestStatusFunc) error {
 	for _, updateStatusFunc := range statusFuncs {
 		updateStatusFunc()

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -12,6 +12,7 @@ const (
 	ErrStatusCode  = "HTTP %s request failed with status code: %s"
 )
 
+// IsRequestValid checks if an HTTP request is valid.
 func IsRequestValid(method string, url string) error {
 	if method == "" {
 		return errors.New(errEmptyMethod)


### PR DESCRIPTION
### Description
This PR modifies the `isObjectValidForObservation` function to improve the handling of POST requests. Previously, the validation relied on the presence of a non-empty response body. However, some APIs (e.g., the one mentioned in the related issue) return an empty body on successful creation, leading to incorrect behavior where the provider attempts repeated creation attempts.

The updated logic now checks for a non-zero `StatusCode`, ensuring that valid responses are not incorrectly excluded from observation.

### Why is this change needed?  
The existing logic fails for APIs that respond with an empty body on successful creation (e.g., HTTP 201). This causes unnecessary retries and results in conflicts (HTTP 409). By updating the validation logic, we ensure proper handling of such cases.

### Changes Made  
- Updated the `isObjectValidForObservation` function:  
  - Changed the check from `cr.Status.Response.Body != ""` to `cr.Status.Response.StatusCode != 0`.  
  - This ensures that the validation focuses on the status code rather than the presence of a body.  
- Updated the related unit tests.

### Related Issues  
Resolves: #68 
