### PR TITLE
fix: use new secretInjectionConfigs keyMappings field in resource docs

### DIFF
--- a/resources-docs/disposablerequest_docs.md
+++ b/resources-docs/disposablerequest_docs.md
@@ -32,13 +32,11 @@ Here is an example `DisposableRequest` resource definition:
           - secretRef:
               name: response-secret
               namespace: default
-            secretKey: extracted-data
-            responsePath: .body.reminder
-          - secretRef:
-              name: response-secret
-              namespace: default
-            secretKey: extracted-data-headers
-            responsePath: .headers.Try[0]
+            keyMappings:
+              - secretKey: extracted-data
+                responseJQ: .body.reminder
+              - secretKey: extracted-data-headers
+                responseJQ: .headers.Try[0]
 ```
 
 -  deletionPolicy: specifies what will happen to the underlying external when this managed resource is   deleted. in this case it should be set to "Orphan" the external resource.


### PR DESCRIPTION
### Description of your changes

The example for DisposableRequest in the resource-docs still uses the deprecated `secretKey` and `responsePath` fields of `SecretInjectionConfigs`. This PR updates the docs to make it more in line with the examples in the `examples` folder.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A
