### PR TITLE
Add Support for Additional HTTP Methods in Method Field

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.6)"
+        description: "Release version (e.g. v1.0.7)"
         required: true
       channel:
         description: "Release channel"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.6)"
+        description: "Release version (e.g. v1.0.7)"
         required: true
       message:
         description: "Tag message"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install `provider-http`, you have two options:
 1. Using the Crossplane CLI in a Kubernetes cluster where Crossplane is installed:
 
    ```console
-   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.6
+   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.7
    ```
 
 2. Manually creating a Provider by applying the following YAML:
@@ -20,7 +20,7 @@ To install `provider-http`, you have two options:
    metadata:
      name: provider-http
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.6"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.7"
    ```
 
 ## Supported Resources

--- a/apis/request/v1alpha2/request_types.go
+++ b/apis/request/v1alpha2/request_types.go
@@ -41,6 +41,8 @@ const (
 // RequestParameters are the configurable fields of a Request.
 type RequestParameters struct {
 	// Mappings defines the HTTP mappings for different methods.
+	// Either Method or Action must be specified. If both are omitted, the mapping will not be used.
+	// +kubebuilder:validation:MinItems=1
 	Mappings []Mapping `json:"mappings"`
 
 	// Payload defines the payload for the request.
@@ -66,8 +68,7 @@ type RequestParameters struct {
 }
 
 type Mapping struct {
-	// Either Method or Action must be specified. If both are omitted, the mapping will not be used.
-	// +kubebuilder:validation:Enum=POST;GET;PUT;DELETE
+	// +kubebuilder:validation:Enum=POST;GET;PUT;DELETE;PATCH;HEAD;OPTIONS
 	// Method specifies the HTTP method for the request.
 	Method string `json:"method,omitempty"`
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: http-provider
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.6
+  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.7
   controllerConfigRef:
     name: debug-config
 

--- a/package/crds/http.crossplane.io_requests.yaml
+++ b/package/crds/http.crossplane.io_requests.yaml
@@ -513,8 +513,9 @@ spec:
                         type: string
                     type: object
                   mappings:
-                    description: Mappings defines the HTTP mappings for different
-                      methods.
+                    description: |-
+                      Mappings defines the HTTP mappings for different methods.
+                      Either Method or Action must be specified. If both are omitted, the mapping will not be used.
                     items:
                       properties:
                         action:
@@ -537,14 +538,15 @@ spec:
                           description: Headers specifies the headers for the request.
                           type: object
                         method:
-                          description: |-
-                            Either Method or Action must be specified. If both are omitted, the mapping will not be used.
-                            Method specifies the HTTP method for the request.
+                          description: Method specifies the HTTP method for the request.
                           enum:
                           - POST
                           - GET
                           - PUT
                           - DELETE
+                          - PATCH
+                          - HEAD
+                          - OPTIONS
                           type: string
                         url:
                           description: URL specifies the URL for the request.
@@ -552,6 +554,7 @@ spec:
                       required:
                       - url
                       type: object
+                    minItems: 1
                     type: array
                   payload:
                     description: Payload defines the payload for the request.
@@ -920,14 +923,15 @@ spec:
                     description: Headers specifies the headers for the request.
                     type: object
                   method:
-                    description: |-
-                      Either Method or Action must be specified. If both are omitted, the mapping will not be used.
-                      Method specifies the HTTP method for the request.
+                    description: Method specifies the HTTP method for the request.
                     enum:
                     - POST
                     - GET
                     - PUT
                     - DELETE
+                    - PATCH
+                    - HEAD
+                    - OPTIONS
                     type: string
                   url:
                     description: URL specifies the URL for the request.


### PR DESCRIPTION
This PR extends the supported HTTP methods in the `Method` field of the `Mapping` type of the `Request` managed resource. 
The current implementation only allows `POST`, `GET`, `PUT`, and `DELETE`. However, some remote APIs require additional HTTP methods such as `PATCH`, `HEAD`, or `OPTIONS` for specific actions. 

To address this limitation, this PR updates the `kubebuilder:validation:Enum` marker and the CRD schema to include the following methods:

- `PATCH`
- `HEAD`
- `OPTIONS`

This change ensures that users can define mappings using these methods without encountering validation errors.

### Fixes  
Fixes #76  

### Checklist  
- [x] Read and followed Crossplane's [contribution process].  
- [x] Run `make reviewable test` to ensure this PR is ready for review.  
