### PR TITLE
Add MissingFieldStrategy for KeyInjection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
-GOLANGCILINT_VERSION = 1.51.2
+GOLANGCILINT_VERSION = 1.55.2
 -include build/makelib/golang.mk
 
 # ====================================================================================

--- a/apis/common/secrets_injections.go
+++ b/apis/common/secrets_injections.go
@@ -32,6 +32,18 @@ type SecretInjectionConfig struct {
 	SetOwnerReference bool `json:"setOwnerReference,omitempty"`
 }
 
+// MissingFieldStrategy defines how to handle missing fields in the response
+type MissingFieldStrategy string
+
+const (
+	// PreserveMissingField keeps the existing value in the secret when the field is missing from the response
+	PreserveMissingField MissingFieldStrategy = "preserve"
+	// SetNullMissingField sets the value to null/empty when the field is missing from the response
+	SetNullMissingField MissingFieldStrategy = "setNull"
+	// DeleteMissingField removes the key from the secret when the field is missing from the response
+	DeleteMissingField MissingFieldStrategy = "delete"
+)
+
 // KeyInjection represents the configuration for injecting data into a specific key in a Kubernetes secret.
 type KeyInjection struct {
 	// SecretKey is the key within the Kubernetes secret where the data will be injected.
@@ -39,6 +51,15 @@ type KeyInjection struct {
 
 	// ResponseJQ is a jq filter expression representing the path in the response where the secret value will be extracted from.
 	ResponseJQ string `json:"responseJQ"`
+
+	// MissingFieldStrategy determines how to handle cases where the field is missing from the response.
+	// Possible values are:
+	// - "preserve": keeps the existing value in the secret
+	// - "setNull": sets the value to null/empty
+	// - "delete": removes the key from the s
+	// +kubebuilder:validation:Enum=preserve;setNull;delete
+	// +kubebuilder:default=delete
+	MissingFieldStrategy MissingFieldStrategy `json:"missingFieldStrategy,omitempty"`
 }
 
 // Metadata contains labels and annotations to apply to a Kubernetes secret.

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	k8s.io/component-base v0.29.1 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/internal/data-patcher/patch.go
+++ b/internal/data-patcher/patch.go
@@ -76,13 +76,20 @@ func applySecretConfig(ctx context.Context, localKube client.Client, logger logg
 
 	if secretConfig.KeyMappings != nil {
 		for _, mapping := range secretConfig.KeyMappings {
-			err = updateSecretWithPatchedValue(ctx, localKube, logger, data, secret, mapping.SecretKey, mapping.ResponseJQ)
+			err = updateSecretWithPatchedValue(ctx, localKube, logger, data, secret, mapping)
 			if err != nil {
 				return errors.Wrap(err, errPatchToReferencedSecret)
 			}
 		}
 	} else {
-		err = updateSecretWithPatchedValue(ctx, localKube, logger, data, secret, secretConfig.SecretKey, secretConfig.ResponsePath)
+		// Handle deprecated secretConfig fields
+		mapping := common.KeyInjection{
+			SecretKey:            secretConfig.SecretKey,
+			ResponseJQ:           secretConfig.ResponsePath,
+			MissingFieldStrategy: common.DeleteMissingField,
+		}
+
+		err = updateSecretWithPatchedValue(ctx, localKube, logger, data, secret, mapping)
 		if err != nil {
 			return errors.Wrap(err, errPatchToReferencedSecret)
 		}

--- a/internal/data-patcher/secret_patcher.go
+++ b/internal/data-patcher/secret_patcher.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/crossplane-contrib/provider-http/apis/common"
 	httpClient "github.com/crossplane-contrib/provider-http/internal/clients/http"
 	"github.com/crossplane-contrib/provider-http/internal/jq"
 	json_util "github.com/crossplane-contrib/provider-http/internal/json"
@@ -56,7 +57,7 @@ func updateSecretLabelsAndAnnotations(ctx context.Context, kubeClient client.Cli
 // updateSecretWithPatchedValue extracts a specified value from an HTTP response,
 // transforms it if necessary, and patches it into a Kubernetes Secret. Additionally,
 // it replaces the sensitive value in the HTTP response body and headers with a placeholder.
-func updateSecretWithPatchedValue(ctx context.Context, kubeClient client.Client, logger logging.Logger, data *httpClient.HttpResponse, secret *corev1.Secret, secretKey string, requestFieldPath string) error {
+func updateSecretWithPatchedValue(ctx context.Context, kubeClient client.Client, logger logging.Logger, data *httpClient.HttpResponse, secret *corev1.Secret, mapping common.KeyInjection) error {
 	// Step 1: Parse and prepare data
 	dataMap, err := prepareDataMap(data)
 	if err != nil {
@@ -64,18 +65,13 @@ func updateSecretWithPatchedValue(ctx context.Context, kubeClient client.Client,
 	}
 
 	// Step 2: Extract the value to patch
-	valueToPatch := extractValueToPatch(logger, dataMap, requestFieldPath)
+	valueToPatch := extractValueToPatch(logger, dataMap, mapping.ResponseJQ)
 
-	// Step 3: Check if the value is already present
-	if isSecretDataUpToDate(secret, secretKey, valueToPatch) {
-		return nil
-	}
+	// Step 3: Update the secret data based on the missing strategy.
+	updateSecretData(secret, mapping.SecretKey, valueToPatch, mapping.MissingFieldStrategy)
 
-	// Step 4: Update the secret data
-	updateSecretData(secret, secretKey, valueToPatch)
-
-	// Step 5: Replace sensitive values in the HTTP response
-	replaceSensitiveValues(data, secret, secretKey, valueToPatch)
+	// Step 4: Replace sensitive values in the HTTP response (only if the field was found).
+	replaceSensitiveValues(data, secret, mapping.SecretKey, valueToPatch)
 
 	// Step 5: Save the updated secret to the Kubernetes API
 	return kubehandler.UpdateSecret(ctx, kubeClient, secret)
@@ -92,54 +88,82 @@ func prepareDataMap(data *httpClient.HttpResponse) (map[string]interface{}, erro
 }
 
 // extractValueToPatch extracts a value from a data map based on the given field path.
-// If the field is a boolean, it converts it to a string.
-func extractValueToPatch(logger logging.Logger, dataMap map[string]interface{}, requestFieldPath string) string {
-	// Attempt to parse the field as a string
-	valueToPatch, err := jq.ParseString(requestFieldPath, dataMap)
-	if err == nil {
-		return valueToPatch
+// If the field is a boolean or number, it converts it to a string.
+// If the field is not found or cannot be parsed, it returns nil.
+func extractValueToPatch(logger logging.Logger, dataMap map[string]interface{}, requestFieldPath string) *string {
+	// Check if the field exists
+	exists, err := jq.Exists(requestFieldPath, dataMap)
+	if err != nil {
+		logger.Debug(fmt.Sprintf("Error checking existence of field %s: %s", requestFieldPath, err))
+		return nil
 	}
-	logger.Debug(fmt.Sprintf("Failed to parse the field %s as a string: %s", requestFieldPath, err))
+	if !exists {
+		return nil
+	}
+
+	// Attempt to parse the field as a string.
+	if valueToPatch, err := jq.ParseString(requestFieldPath, dataMap); err == nil {
+		return &valueToPatch
+	} else {
+		logger.Debug(fmt.Sprintf("Failed to parse the field %s as a string: %s", requestFieldPath, err))
+	}
 
 	// Attempt to parse the field as a boolean
-	boolResult, boolErr := jq.ParseBool(requestFieldPath, dataMap)
-	if boolErr == nil {
-		return strconv.FormatBool(boolResult)
+	if boolResult, boolErr := jq.ParseBool(requestFieldPath, dataMap); boolErr == nil {
+		boolStr := strconv.FormatBool(boolResult)
+		return &boolStr
+	} else {
+		logger.Debug(fmt.Sprintf("Failed to parse the field %s as a boolean: %s", requestFieldPath, boolErr))
 	}
-	logger.Debug(fmt.Sprintf("Failed to parse the field %s as a boolean: %s", requestFieldPath, boolErr))
 
-	// Attempt to parse the field as a number
-	numberResult, numberErr := jq.ParseFloat(requestFieldPath, dataMap)
-	if numberErr == nil {
-		return strconv.FormatFloat(numberResult, 'f', -1, 64)
+	// Attempt to parse the field as a number.
+	if numberResult, err := jq.ParseFloat(requestFieldPath, dataMap); err == nil {
+		numStr := strconv.FormatFloat(numberResult, 'f', -1, 64)
+		return &numStr
+	} else {
+		logger.Debug(fmt.Sprintf("Failed to parse the field %s as a number: %s", requestFieldPath, err))
 	}
-	logger.Debug(fmt.Sprintf("Failed to parse the field %s as a number: %s", requestFieldPath, numberErr))
 
-	logger.Info(fmt.Sprintf("Failed to parse the field %s as a string, boolean, or number: %s, setting an empty string instead.", requestFieldPath, err))
-	return ""
+	logger.Info(fmt.Sprintf("Failed to parse the field %s as a string, boolean, or number, treating it as missing field.", requestFieldPath))
+	return nil
 }
 
-// updateSecretData updates the data field of a Kubernetes Secret with the given key and value.
-func updateSecretData(secret *corev1.Secret, secretKey, valueToPatch string) {
+// updateSecretData updates the data field of a Kubernetes Secret with the given key.
+// If valueToPatch is non-nil, it updates the secret with the provided value.
+// If valueToPatch is nil, then the missingStrategy is used:
+//   - common.PreserveMissingField: does nothing
+//   - common.SetNullMissingField: sets the value to ""
+//   - common.DeleteMissingField: deletes the key from the secret if it exists.
+func updateSecretData(secret *corev1.Secret, secretKey string, valueToPatch *string, missingStrategy common.MissingFieldStrategy) {
 	if secret.Data == nil {
 		secret.Data = make(map[string][]byte)
 	}
-	secret.Data[secretKey] = []byte(valueToPatch)
+	if valueToPatch != nil {
+		secret.Data[secretKey] = []byte(*valueToPatch)
+	} else {
+		switch missingStrategy {
+		case common.PreserveMissingField:
+		case common.SetNullMissingField:
+			secret.Data[secretKey] = []byte("")
+		case common.DeleteMissingField:
+			delete(secret.Data, secretKey)
+		}
+	}
 }
 
 // replaceSensitiveValues replaces occurrences of a sensitive value in the HTTP response body
 // and headers with a placeholder.
-func replaceSensitiveValues(data *httpClient.HttpResponse, secret *corev1.Secret, secretKey, valueToPatch string) {
-	if valueToPatch == "" {
+func replaceSensitiveValues(data *httpClient.HttpResponse, secret *corev1.Secret, secretKey string, valueToPatch *string) {
+	if valueToPatch == nil || *valueToPatch == "" {
 		return
 	}
 
 	placeholder := fmt.Sprintf("{{%s:%s:%s}}", secret.Name, secret.Namespace, secretKey)
-	data.Body = strings.ReplaceAll(data.Body, valueToPatch, placeholder)
+	data.Body = strings.ReplaceAll(data.Body, *valueToPatch, placeholder)
 
 	for _, headersList := range data.Headers {
 		for i, header := range headersList {
-			headersList[i] = strings.ReplaceAll(header, valueToPatch, placeholder)
+			headersList[i] = strings.ReplaceAll(header, *valueToPatch, placeholder)
 		}
 	}
 }
@@ -160,8 +184,8 @@ func syncMap(logger logging.Logger, existing *map[string]string, desired map[str
 	for key, value := range desired {
 		if jq.IsJQQuery(value) {
 			newValue := extractValueToPatch(logger, dataMap, value)
-			if len(newValue) != 0 {
-				value = newValue
+			if newValue != nil {
+				value = *newValue
 			}
 		}
 		if (*existing)[key] != value {

--- a/internal/data-patcher/secret_patcher_test.go
+++ b/internal/data-patcher/secret_patcher_test.go
@@ -3,11 +3,13 @@ package datapatcher
 import (
 	"testing"
 
+	"github.com/crossplane-contrib/provider-http/apis/common"
 	httpClient "github.com/crossplane-contrib/provider-http/internal/clients/http"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestIsSecretDataUpToDate(t *testing.T) {
@@ -175,7 +177,7 @@ func TestReplaceSensitiveValues(t *testing.T) {
 		data         *httpClient.HttpResponse
 		secret       *corev1.Secret
 		secretKey    string
-		valueToPatch string
+		valueToPatch *string
 	}
 
 	type want struct {
@@ -203,7 +205,7 @@ func TestReplaceSensitiveValues(t *testing.T) {
 					},
 				},
 				secretKey:    "sensitiveKey",
-				valueToPatch: "sensitive-value",
+				valueToPatch: ptr.To("sensitive-value"),
 			},
 			want: want{
 				body: "Sensitive value is here.",
@@ -228,7 +230,7 @@ func TestReplaceSensitiveValues(t *testing.T) {
 					},
 				},
 				secretKey:    "sensitiveKey",
-				valueToPatch: "",
+				valueToPatch: ptr.To(""),
 			},
 			want: want{
 				body: "Nothing to replace here.",
@@ -252,7 +254,7 @@ func TestReplaceSensitiveValues(t *testing.T) {
 					},
 				},
 				secretKey:    "sensitiveKey",
-				valueToPatch: "value",
+				valueToPatch: ptr.To("value"),
 			},
 			want: want{
 				body: "Sensitive {{my-secret:default:sensitiveKey}} in the body.",
@@ -280,9 +282,10 @@ func TestReplaceSensitiveValues(t *testing.T) {
 
 func TestUpdateSecretData(t *testing.T) {
 	type args struct {
-		secret       *corev1.Secret
-		secretKey    string
-		valueToPatch string
+		secret          *corev1.Secret
+		secretKey       string
+		valueToPatch    *string
+		missingStrategy common.MissingFieldStrategy
 	}
 
 	type want struct {
@@ -297,7 +300,7 @@ func TestUpdateSecretData(t *testing.T) {
 			args: args{
 				secret:       &corev1.Secret{},
 				secretKey:    "key1",
-				valueToPatch: "value1",
+				valueToPatch: ptr.To("value1"),
 			},
 			want: want{
 				data: map[string][]byte{
@@ -313,7 +316,7 @@ func TestUpdateSecretData(t *testing.T) {
 					},
 				},
 				secretKey:    "key1",
-				valueToPatch: "newValue",
+				valueToPatch: ptr.To("newValue"),
 			},
 			want: want{
 				data: map[string][]byte{
@@ -329,7 +332,7 @@ func TestUpdateSecretData(t *testing.T) {
 					},
 				},
 				secretKey:    "key2",
-				valueToPatch: "value2",
+				valueToPatch: ptr.To("value2"),
 			},
 			want: want{
 				data: map[string][]byte{
@@ -342,7 +345,7 @@ func TestUpdateSecretData(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			updateSecretData(tc.args.secret, tc.args.secretKey, tc.args.valueToPatch)
+			updateSecretData(tc.args.secret, tc.args.secretKey, tc.args.valueToPatch, tc.args.missingStrategy)
 
 			if diff := cmp.Diff(tc.want.data, tc.args.secret.Data); diff != "" {
 				t.Errorf("updateSecretData(...): -want data, +got data: %s", diff)
@@ -358,7 +361,7 @@ func TestExtractValueToPatch(t *testing.T) {
 	}
 
 	type want struct {
-		result string
+		result *string
 		err    error
 	}
 
@@ -374,7 +377,7 @@ func TestExtractValueToPatch(t *testing.T) {
 				requestFieldPath: ".stringField",
 			},
 			want: want{
-				result: "testString",
+				result: ptr.To("testString"),
 				err:    nil,
 			},
 		},
@@ -386,7 +389,7 @@ func TestExtractValueToPatch(t *testing.T) {
 				requestFieldPath: ".booleanField",
 			},
 			want: want{
-				result: "true",
+				result: ptr.To("true"),
 				err:    nil,
 			},
 		},
@@ -398,7 +401,7 @@ func TestExtractValueToPatch(t *testing.T) {
 				requestFieldPath: ".numberField",
 			},
 			want: want{
-				result: "123.45",
+				result: ptr.To("123.45"),
 				err:    nil,
 			},
 		},
@@ -410,7 +413,7 @@ func TestExtractValueToPatch(t *testing.T) {
 				requestFieldPath: ".nonExistentField",
 			},
 			want: want{
-				result: "",
+				result: nil,
 				err:    nil,
 			},
 		},
@@ -422,7 +425,7 @@ func TestExtractValueToPatch(t *testing.T) {
 				requestFieldPath: ".arrayField",
 			},
 			want: want{
-				result: "",
+				result: nil,
 				err:    nil,
 			},
 		},

--- a/internal/jq/parser.go
+++ b/internal/jq/parser.go
@@ -144,3 +144,26 @@ func IsJQQuery(query string) bool {
 	_, err := gojq.Parse(query)
 	return err == nil
 }
+
+// Exists checks if the given jq query returns a non-nil value from the object.
+// It returns true if the field exists, false otherwise.
+func Exists(jqQuery string, obj interface{}) (bool, error) {
+	query, err := gojq.Parse(jqQuery)
+	if err != nil {
+		return false, err
+	}
+
+	mutex.Lock()
+	iter := query.Run(obj)
+	result, ok := iter.Next()
+	mutex.Unlock()
+
+	if !ok || result == nil {
+		return false, nil
+	}
+
+	if errResult, isErr := result.(error); isErr {
+		return false, errResult
+	}
+	return true, nil
+}

--- a/package/crds/http.crossplane.io_disposablerequests.yaml
+++ b/package/crds/http.crossplane.io_disposablerequests.yaml
@@ -498,6 +498,19 @@ spec:
                               for injecting data into a specific key in a Kubernetes
                               secret.
                             properties:
+                              missingFieldStrategy:
+                                default: delete
+                                description: |-
+                                  MissingFieldStrategy determines how to handle cases where the field is missing from the response.
+                                  Possible values are:
+                                  - "preserve": keeps the existing value in the secret
+                                  - "setNull": sets the value to null/empty
+                                  - "delete": removes the key from the s
+                                enum:
+                                - preserve
+                                - setNull
+                                - delete
+                                type: string
                               responseJQ:
                                 description: ResponseJQ is a jq filter expression
                                   representing the path in the response where the

--- a/package/crds/http.crossplane.io_requests.yaml
+++ b/package/crds/http.crossplane.io_requests.yaml
@@ -582,6 +582,19 @@ spec:
                               for injecting data into a specific key in a Kubernetes
                               secret.
                             properties:
+                              missingFieldStrategy:
+                                default: delete
+                                description: |-
+                                  MissingFieldStrategy determines how to handle cases where the field is missing from the response.
+                                  Possible values are:
+                                  - "preserve": keeps the existing value in the secret
+                                  - "setNull": sets the value to null/empty
+                                  - "delete": removes the key from the s
+                                enum:
+                                - preserve
+                                - setNull
+                                - delete
+                                type: string
                               responseJQ:
                                 description: ResponseJQ is a jq filter expression
                                   representing the path in the response where the


### PR DESCRIPTION
### Description of your changes

This implements MissingFieldStrategy as discussed in #81. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

@arielsepton The existing tests work already. Feel free to already check if the implementation.
I will now proceed to add / improve the tests to test each of the 3 different strategies for handling missing fields.
Then, I will also test it manually in my local setup.
