### PR TITLE
chore: bump version to v1.0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: make -j2 test
 
       - name: Publish Unit Test Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
         with:
           flags: unittests
           file: _output/tests/linux_amd64/coverage.txt

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.8)"
+        description: "Release version (e.g. v1.0.10)"
         required: true
       channel:
         description: "Release channel"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.8)"
+        description: "Release version (e.g. v1.0.10)"
         required: true
       message:
         description: "Tag message"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install `provider-http`, you have two options:
 1. Using the Crossplane CLI in a Kubernetes cluster where Crossplane is installed:
 
    ```console
-   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.8
+   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.10
    ```
 
 2. Manually creating a Provider by applying the following YAML:
@@ -20,7 +20,7 @@ To install `provider-http`, you have two options:
    metadata:
      name: provider-http
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.8"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.10"
    ```
 
 ## Supported Resources

--- a/deploy.yml
+++ b/deploy.yml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: http-provider
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.8
+  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.10
   controllerConfigRef:
     name: debug-config
 


### PR DESCRIPTION
Signed-off-by: Ariel Septon <64063409+arielsepton@users.noreply.github.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description

This PR updates the project version to v1.0.10.
Includes no functional changes — version bump only for release tagging and distribution.