### PR TITLE
fix: logging setup

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -53,12 +53,7 @@ func main() {
 
 	zl := zap.New(zap.UseDevMode(*debug))
 	log := logging.NewLogrLogger(zl.WithName("provider-http"))
-	if *debug {
-		// The controller-runtime runs with a no-op logger by default. It is
-		// *very* verbose even at info level, so we only provide it a real
-		// logger when we're running in debug mode.
-		ctrl.SetLogger(zl)
-	}
+	ctrl.SetLogger(zl)
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")


### PR DESCRIPTION
### Fix: Ensure controller-runtime logger is always set

This PR removes the conditional check around `ctrl.SetLogger(zl)`, which previously only set the logger when the `--debug` flag was enabled. Without this call, controller-runtime defaults to a no-op logger, leading to the following warning:

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
```

This results in the absence of controller logs, significantly hampering debugging and observability.

By always setting the logger, we ensure that logs are emitted regardless of the debug flag, improving the developer and user experience.

### Related Issue

Fixes: #93 