### PR TITLE
build: pass robot token credentials to publishing to mirror registry

### DIFF
--- a/.github/workflows/publish-provider-package.yaml
+++ b/.github/workflows/publish-provider-package.yaml
@@ -22,4 +22,5 @@ jobs:
       cleanup-disk: true
     secrets:
       GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
-      XPKG_UPBOUND_TOKEN: ${{ secrets.XPKG_TOKEN }}
+      XPKG_MIRROR_TOKEN: ${{ secrets.XPKG_TOKEN }}
+      XPKG_MIRROR_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}


### PR DESCRIPTION
### Description of your changes

This PR updates the publishing workflow to pass robot token credentials to the reusable workflow. The workflow was updated to explicitly expect robot tokens in https://github.com/crossplane-contrib/provider-workflows/pull/15/.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

We will test this in publishing from main after this is merged, but this same update has been successfully applied and tested in https://github.com/crossplane-contrib/provider-kubernetes/pull/368 and https://github.com/crossplane-contrib/provider-spotify/pull/17 already 😇 

[contribution process]: https://git.io/fj2m9
