### PR TITLE
fix: apply secret injection configs on synced DisposableRequests

### DIFF
--- a/internal/data-patcher/secret_patcher.go
+++ b/internal/data-patcher/secret_patcher.go
@@ -57,9 +57,9 @@ func updateSecretLabelsAndAnnotations(ctx context.Context, kubeClient client.Cli
 // updateSecretWithPatchedValue extracts a specified value from an HTTP response,
 // transforms it if necessary, and patches it into a Kubernetes Secret. Additionally,
 // it replaces the sensitive value in the HTTP response body and headers with a placeholder.
-func updateSecretWithPatchedValue(ctx context.Context, kubeClient client.Client, logger logging.Logger, data *httpClient.HttpResponse, secret *corev1.Secret, mapping common.KeyInjection) error {
+func updateSecretWithPatchedValue(ctx context.Context, kubeClient client.Client, logger logging.Logger, data, originalData *httpClient.HttpResponse, secret *corev1.Secret, mapping common.KeyInjection) error {
 	// Step 1: Parse and prepare data
-	dataMap, err := prepareDataMap(data)
+	dataMap, err := prepareDataMap(originalData)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Apply secret injection configs on already-synced DisposableRequests


**Description:**
This PR ensures that updates to secret injection configurations (e.g., `keyMappings`) are correctly applied even when a `DisposableRequest` resource is already marked as synced.

**Changes:**

* Update `deployAction` to apply secret injections when the resource is already synced.
* Add `applySecretInjectionsFromStoredResponse` to handle config updates from stored responses.
* Fix `ApplyResponseDataToSecrets` to preserve original data for extraction.
* Ensure secret configs are applied consistently, regardless of sync status.

**Reason:**
Previously, updates to secret injection configs were ignored for synced resources, because deployment actions were skipped entirely. This caused existing secrets to remain outdated when `keyMappings` were modified.

Fixes #104 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Ran all existing tests to confirm no regressions.


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
