### PR TITLE
fix: enhance secret injection handling based on response validation

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.10)"
+        description: "Release version (e.g. v1.0.11)"
         required: true
       channel:
         description: "Release channel"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.10)"
+        description: "Release version (e.g. v1.0.11)"
         required: true
       message:
         description: "Tag message"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install `provider-http`, you have two options:
 1. Using the Crossplane CLI in a Kubernetes cluster where Crossplane is installed:
 
    ```console
-   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.10
+   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.11
    ```
 
 2. Manually creating a Provider by applying the following YAML:
@@ -20,7 +20,7 @@ To install `provider-http`, you have two options:
    metadata:
      name: provider-http
    spec:
-     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.10"
+     package: "xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.11"
    ```
 
 ## Supported Resources

--- a/deploy.yml
+++ b/deploy.yml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: http-provider
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.10
+  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.11
   controllerConfigRef:
     name: debug-config
 


### PR DESCRIPTION

### Description 

This PR fixes an issue where **`secretInjectionConfigs` were applied even when `expectedResponse` evaluated to `false`**.

Previously, secrets were always created if `secretInjectionConfigs` were defined, regardless of whether the response matched the `expectedResponse` condition. This resulted in secrets being populated with error responses (e.g., HTTP 500 bodies), even though the resource was expected to fail and skip secret injection.

With this change:

* Secret injection now only occurs when `expectedResponse` evaluates to `true`, and no error occured.
* If `expectedResponse` evaluates to `false`, secret injection is skipped.
* This prevents unintended secrets from being created or overwritten with error responses.

### How has this been tested?

* Reproduced the issue using the provided Python webserver scenario (see linked issues).
* Verified that the `DisposableRequest` with a failing `expectedResponse` no longer injects secrets.
* Confirmed that successful responses continue to inject secrets as expected.
* Ran existing unit and integration tests to ensure no regressions.

### Related issues

* Fixes #86
* Related to #78, #79

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
