### PR TITLE
fix(apis): cache response should return cached response instead of failed response

### DIFF
--- a/apis/cluster/request/v1alpha2/spec_accessors.go
+++ b/apis/cluster/request/v1alpha2/spec_accessors.go
@@ -160,10 +160,10 @@ var _ interfaces.CachedResponse = (*Request)(nil)
 
 // GetCachedResponse returns the cached response from the status.
 func (r *Request) GetCachedResponse() interfaces.HTTPResponse {
-	if r.Status.Response.StatusCode == 0 {
+	if r.Status.Cache.Response.StatusCode == 0 {
 		return nil
 	}
-	return &r.Status.Response
+	return &r.Status.Cache.Response
 }
 
 // Ensure Request implements RequestStatusReader

--- a/apis/cluster/request/v1alpha2/spec_accessors_test.go
+++ b/apis/cluster/request/v1alpha2/spec_accessors_test.go
@@ -176,9 +176,11 @@ func TestRequest_CachedResponse(t *testing.T) {
 	// Test with cached response
 	req := &Request{
 		Status: RequestStatus{
-			Response: Response{
-				StatusCode: 200,
-				Body:       "cached",
+			Cache: Cache{
+				Response: Response{
+					StatusCode: 200,
+					Body:       "cached",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Dear maintainers,

Fixes #152

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

locally with the description mentioned in the issue.
