### PR TITLE
chore: update deploy.yml to use DeploymentRuntimeConfig instead of ControllerConfig

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.11)"
+        description: "Release version (e.g. v1.0.12)"
         required: true
       channel:
         description: "Release channel"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v1.0.11)"
+        description: "Release version (e.g. v1.0.12)"
         required: true
       message:
         description: "Tag message"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install `provider-http`, you have two options:
 1. Using the Crossplane CLI in a Kubernetes cluster where Crossplane is installed:
 
    ```console
-   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.11
+   crossplane xpkg install provider xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.12
    ```
 
 2. Manually creating a Provider by applying the following YAML:
@@ -20,7 +20,7 @@ To install `provider-http`, you have two options:
    metadata:
      name: provider-http
    spec:
-     package: 'xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.11'
+     package: 'xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.12'
    ```
 
 ## Supported Resources

--- a/deploy.yml
+++ b/deploy.yml
@@ -5,7 +5,7 @@ kind: Provider
 metadata:
   name: provider-http
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.11
+  package: xpkg.upbound.io/crossplane-contrib/provider-http:v1.0.12
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I updated the `./deploy.yml` to use `DeploymentRuntimeConfig` instead of `ControllerConfig` since it was removed in Crossplane v2

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I successfully applied the new `deploy.yml` into a local `kind` Cluster with Crossplane `2.1` installed.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
