### PR TITLE
Fix: DisposableRequest nextReconcile handling and add e2e coverage

### DIFF
--- a/examples/sample/disposablerequest-nextreconcile.yaml
+++ b/examples/sample/disposablerequest-nextreconcile.yaml
@@ -1,0 +1,33 @@
+apiVersion: http.m.crossplane.io/v1alpha2
+kind: DisposableRequest
+metadata:
+  name: sample-nextreconcile
+  namespace: default
+  annotations:
+    # Run a pre-assert check to ensure the test server is reachable (relative to this manifest file)
+    uptest.upbound.io/pre-assert-hook: ../../test/hooks/check-test-server.sh
+    # Run the verification script after the resource is asserted by uptest (relative to this manifest file)
+    uptest.upbound.io/post-assert-hook: ../../test/hooks/verify-next-reconcile.sh
+spec:
+  forProvider:
+    url: http://test-server.default.svc.cluster.local/v1/notify
+    method: POST
+    body: |
+      { "recipient": "sample@example.com", "subject": "e2e", "message": "test" }
+    headers:
+      Content-Type:
+        - application/json
+      Authorization:
+        - "Bearer {{ auth:default:token }}"
+    insecureSkipTLSVerify: true
+    # expectedResponse evaluates a jq expression against the recorded response.
+    # The response body is available under the `body` key, so check `body.status`.
+    expectedResponse: '.body.status == "sent"'
+    rollbackRetriesLimit: 1
+    shouldLoopInfinitely: true
+    # Verify the controller honors this duration in e2e; short for test speed.
+    nextReconcile: 1m
+    waitTimeout: 10s
+  providerConfigRef:
+    name: http-conf-namespaced
+    kind: ProviderConfig

--- a/internal/controller/cluster/disposablerequest/poll_hook_test.go
+++ b/internal/controller/cluster/disposablerequest/poll_hook_test.go
@@ -1,0 +1,71 @@
+package disposablerequest
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha2 "github.com/crossplane-contrib/provider-http/apis/cluster/disposablerequest/v1alpha2"
+)
+
+func TestCustomPollIntervalHook_Cluster(t *testing.T) {
+	defaultPoll := 30 * time.Second
+
+	now := time.Now()
+
+	cases := map[string]struct {
+		cr   *v1alpha2.DisposableRequest
+		want time.Duration
+	}{
+		"nil nextReconcile": {
+			cr:   &v1alpha2.DisposableRequest{},
+			want: defaultPoll,
+		},
+		"zero lastReconcile + nextReconcile set": {
+			cr: &v1alpha2.DisposableRequest{
+				Spec: v1alpha2.DisposableRequestSpec{
+					ForProvider: v1alpha2.DisposableRequestParameters{
+						NextReconcile: &metav1.Duration{Duration: 2 * time.Hour},
+					},
+				},
+			},
+			want: 2 * time.Hour,
+		},
+		"past lastReconcile with remaining time": {
+			cr: &v1alpha2.DisposableRequest{
+				Spec: v1alpha2.DisposableRequestSpec{
+					ForProvider: v1alpha2.DisposableRequestParameters{
+						NextReconcile: &metav1.Duration{Duration: time.Hour},
+					},
+				},
+				Status: v1alpha2.DisposableRequestStatus{
+					LastReconcileTime: metav1.NewTime(now.Add(-15 * time.Minute)),
+				},
+			},
+			want: 45 * time.Minute,
+		},
+		"nextReconcile already passed": {
+			cr: &v1alpha2.DisposableRequest{
+				Spec: v1alpha2.DisposableRequestSpec{
+					ForProvider: v1alpha2.DisposableRequestParameters{
+						NextReconcile: &metav1.Duration{Duration: time.Second},
+					},
+				},
+				Status: v1alpha2.DisposableRequestStatus{
+					LastReconcileTime: metav1.NewTime(now.Add(-time.Hour)),
+				},
+			},
+			want: defaultPoll,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := customPollIntervalHook(tc.cr, 0)
+			if diff := got - tc.want; diff > 2*time.Second || diff < -2*time.Second {
+				t.Fatalf("%s: want ~%v, got %v", name, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/controller/namespaced/disposablerequest/disposablerequest.go
+++ b/internal/controller/namespaced/disposablerequest/disposablerequest.go
@@ -231,6 +231,23 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	isUpToDate = disposablerequest.CalculateUpToDateStatus(crCtx, isUpToDate)
 
+	// If nextReconcile is configured, and the next reconcile time has passed,
+	// force the resource to be considered out-of-date so DeployAction runs and
+	// updates LastReconcileTime.
+	if cr.Spec.ForProvider.NextReconcile != nil {
+		nextReconcileDuration := cr.Spec.ForProvider.NextReconcile.Duration
+		last := cr.Status.LastReconcileTime.Time
+		if last.IsZero() {
+			// If last reconcile time isn't set yet, consider now to avoid
+			// triggering an immediate extra reconcile.
+			last = time.Now()
+		}
+		if !time.Now().Before(last.Add(nextReconcileDuration)) {
+			c.logger.Debug("NextReconcile time reached, marking resource as not up-to-date to force deployment")
+			isUpToDate = false
+		}
+	}
+
 	if isAvailable {
 		if err := disposablerequest.UpdateResourceStatus(ctx, cr, c.localKube); err != nil {
 			return managed.ExternalObservation{}, err
@@ -289,31 +306,40 @@ func (c *external) Disconnect(_ context.Context) error {
 
 // WithCustomPollIntervalHook returns a managed.ReconcilerOption that sets a custom poll interval based on the DisposableRequest spec.
 func WithCustomPollIntervalHook() managed.ReconcilerOption {
-	return managed.WithPollIntervalHook(func(mg resource.Managed, pollInterval time.Duration) time.Duration {
-		defaultPollInterval := 30 * time.Second
+	return managed.WithPollIntervalHook(customPollIntervalHook)
+}
 
-		cr, ok := mg.(*v1alpha2.DisposableRequest)
-		if !ok {
-			return defaultPollInterval
-		}
+// customPollIntervalHook computes the duration until the next reconcile based on the
+// DisposableRequest's spec and status. If LastReconcileTime is zero (not yet observed),
+// treat it as now to avoid premature short-interval requeues.
+func customPollIntervalHook(mg resource.Managed, _ time.Duration) time.Duration {
+	defaultPollInterval := 30 * time.Second
 
-		if cr.Spec.ForProvider.NextReconcile == nil {
-			return defaultPollInterval
-		}
-
-		// Calculate next reconcile time based on NextReconcile duration
-		nextReconcileDuration := cr.Spec.ForProvider.NextReconcile.Duration
-		lastReconcileTime := cr.Status.LastReconcileTime.Time
-		nextReconcileTime := lastReconcileTime.Add(nextReconcileDuration)
-
-		// Determine if the current time is past the next reconcile time
-		now := time.Now()
-		if now.Before(nextReconcileTime) {
-			// If not yet time to reconcile, calculate remaining time
-			return nextReconcileTime.Sub(now)
-		}
-
-		// Default poll interval if the next reconcile time is in the past
+	cr, ok := mg.(*v1alpha2.DisposableRequest)
+	if !ok {
 		return defaultPollInterval
-	})
+	}
+
+	if cr.Spec.ForProvider.NextReconcile == nil {
+		return defaultPollInterval
+	}
+
+	// Calculate next reconcile time based on NextReconcile duration
+	nextReconcileDuration := cr.Spec.ForProvider.NextReconcile.Duration
+	lastReconcileTime := cr.Status.LastReconcileTime.Time
+	if lastReconcileTime.IsZero() {
+		// Status update may not have propagated yet; consider last reconcile as now.
+		lastReconcileTime = time.Now()
+	}
+	nextReconcileTime := lastReconcileTime.Add(nextReconcileDuration)
+
+	// Determine if the current time is past the next reconcile time
+	now := time.Now()
+	if now.Before(nextReconcileTime) {
+		// If not yet time to reconcile, calculate remaining time
+		return nextReconcileTime.Sub(now)
+	}
+
+	// Default poll interval if the next reconcile time is in the past
+	return defaultPollInterval
 }

--- a/internal/controller/namespaced/disposablerequest/poll_hook_test.go
+++ b/internal/controller/namespaced/disposablerequest/poll_hook_test.go
@@ -1,0 +1,72 @@
+package disposablerequest
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha2 "github.com/crossplane-contrib/provider-http/apis/namespaced/disposablerequest/v1alpha2"
+)
+
+func TestCustomPollIntervalHook_Namespaced(t *testing.T) {
+	defaultPoll := 30 * time.Second
+
+	now := time.Now()
+
+	cases := map[string]struct {
+		cr   *v1alpha2.DisposableRequest
+		want time.Duration
+	}{
+		"nil nextReconcile": {
+			cr:   &v1alpha2.DisposableRequest{},
+			want: defaultPoll,
+		},
+		"zero lastReconcile + nextReconcile set": {
+			cr: &v1alpha2.DisposableRequest{
+				Spec: v1alpha2.DisposableRequestSpec{
+					ForProvider: v1alpha2.DisposableRequestParameters{
+						NextReconcile: &metav1.Duration{Duration: time.Hour},
+					},
+				},
+			},
+			want: time.Hour,
+		},
+		"past lastReconcile with remaining time": {
+			cr: &v1alpha2.DisposableRequest{
+				Spec: v1alpha2.DisposableRequestSpec{
+					ForProvider: v1alpha2.DisposableRequestParameters{
+						NextReconcile: &metav1.Duration{Duration: time.Hour},
+					},
+				},
+				Status: v1alpha2.DisposableRequestStatus{
+					LastReconcileTime: metav1.NewTime(now.Add(-30 * time.Minute)),
+				},
+			},
+			want: 30 * time.Minute,
+		},
+		"nextReconcile already passed": {
+			cr: &v1alpha2.DisposableRequest{
+				Spec: v1alpha2.DisposableRequestSpec{
+					ForProvider: v1alpha2.DisposableRequestParameters{
+						NextReconcile: &metav1.Duration{Duration: time.Second},
+					},
+				},
+				Status: v1alpha2.DisposableRequestStatus{
+					LastReconcileTime: metav1.NewTime(now.Add(-time.Hour)),
+				},
+			},
+			want: defaultPoll,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := customPollIntervalHook(tc.cr, 0)
+			// Allow a 2-second tolerance for the durations that are computed from now
+			if diff := got - tc.want; diff > 2*time.Second || diff < -2*time.Second {
+				t.Fatalf("%s: want ~%v, got %v", name, tc.want, got)
+			}
+		})
+	}
+}

--- a/test/hooks/check-test-server.sh
+++ b/test/hooks/check-test-server.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-test-server.sh
+# Uptest pre-assert hook: wait until the test-server endpoint responds to POST /v1/notify
+
+NAMESPACE=${TEST_NAMESPACE:-default}
+SERVICE_HOST=${TEST_SERVICE_HOST:-test-server.${NAMESPACE}.svc.cluster.local}
+URL="http://${SERVICE_HOST}/v1/notify"
+AUTH_TOKEN=${TEST_AUTH_TOKEN:-my-secret-value}
+TIMEOUT=${TEST_SERVER_TIMEOUT:-120}
+
+echo "check-test-server: waiting for $URL to respond (timeout ${TIMEOUT}s)"
+end=$((SECONDS + TIMEOUT))
+while [ $SECONDS -lt $end ]; do
+  status=$(kubectl -n "$NAMESPACE" run --rm -i --restart=Never curl-test \
+    --image=curlimages/curl --command -- /bin/sh -c \
+    "curl -s -o /dev/null -w '%{http_code}' -H \"Authorization: Bearer ${AUTH_TOKEN}\" -X POST \"${URL}\"" 2>/dev/null || true)
+
+  status=${status//[^0-9]/}
+  if [ "$status" = "201" ]; then
+    echo "check-test-server: endpoint is ready (HTTP $status)"
+    exit 0
+  fi
+  echo "check-test-server: not ready yet (status=$status), retrying..."
+  sleep 3
+done
+
+echo "check-test-server: timeout waiting for $URL"
+exit 1

--- a/test/hooks/verify-next-reconcile.sh
+++ b/test/hooks/verify-next-reconcile.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-next-reconcile.sh
+# Uptest post-assert hook: validate DisposableRequest nextReconcile behavior
+
+NAMESPACE=${TEST_NAMESPACE:-default}
+NAME=${TEST_NAME:-sample-nextreconcile}
+NEXT_RECONCILE_SECONDS=${NEXT_RECONCILE_SECONDS:-60}
+PRE_WINDOW_SECONDS=${PRE_WINDOW_SECONDS:-30}
+SLEEP_BUFFER=${SLEEP_BUFFER:-10}
+
+echo "verify-next-reconcile: validating $NAME in namespace $NAMESPACE"
+
+get_lr() {
+  kubectl get disposablerequests.http.m.crossplane.io "$NAME" -n "$NAMESPACE" -o jsonpath='{.status.lastReconcileTime}' 2>/dev/null || true
+}
+
+echo "Waiting for status.lastReconcileTime to be set (timeout 2m)"
+LR=""
+for i in {1..24}; do
+  LR=$(get_lr)
+  if [[ -n "$LR" ]]; then
+    echo "LastReconcileTime observed: $LR"
+    break
+  fi
+  sleep 5
+done
+
+if [[ -z "$LR" ]]; then
+  echo "ERROR: LastReconcileTime not set within timeout"
+  kubectl -n "$NAMESPACE" describe disposablerequests.http.m.crossplane.io "$NAME" || true
+  exit 1
+fi
+
+to_epoch() {
+  date -u -d "$1" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$1" +%s
+}
+
+T1=$(to_epoch "$LR")
+echo "Recorded last reconcile time: $T1 (epoch)"
+
+echo "Sleeping $PRE_WINDOW_SECONDS seconds (should NOT see a new reconcile yet)"
+sleep $PRE_WINDOW_SECONDS
+
+LR2=$(get_lr)
+T2=$(to_epoch "$LR2")
+
+if [[ "$T2" -ne "$T1" ]]; then
+  echo "FAIL: LastReconcileTime changed too early (T1=$T1, T2=$T2)"
+  kubectl -n "$NAMESPACE" describe disposablerequest "$NAME" || true
+  exit 2
+fi
+echo "PASS: No premature reconcile observed"
+
+WAIT_TOTAL=$((NEXT_RECONCILE_SECONDS + SLEEP_BUFFER))
+echo "Waiting until after nextReconcile: sleeping $WAIT_TOTAL seconds"
+sleep $WAIT_TOTAL
+
+LR3=$(get_lr)
+T3=$(to_epoch "$LR3")
+
+if [[ "$T3" -le "$T1" ]]; then
+  echo "FAIL: LastReconcileTime did not update after nextReconcile (T1=$T1, T3=$T3)"
+  kubectl -n "$NAMESPACE" describe disposablerequest "$NAME" || true
+  exit 3
+fi
+
+echo "PASS: LastReconcileTime updated after nextReconcile (T1=$T1, T3=$T3)"
+echo "verify-next-reconcile: success"


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes an issue where DisposableRequest did not consistently honor spec.forProvider.nextReconcile. In some cases the controller requeued too frequently; in others it did not re-run after the interval elapsed.

This PR corrects the reconcile logic and adds unit + e2e coverage to prevent regressions.

Fixes #156 

### Changes
DisposableRequest controller behavior
- Treat a zero status.lastReconcileTime as now when computing the next reconcile time to avoid premature short requeues.
- In Observe(), when spec.forProvider.nextReconcile is set and the interval has elapsed, explicitly mark the resource as not up to date so DeployAction is triggered and status.lastReconcileTime is updated.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Added unit tests covering custom poll interval behavior for both namespaced and cluster-scoped controllers.
- Ran all existing tests.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
