### PR TITLE
fix: Request REMOVE on deletion and add e2e coverage

### DIFF
--- a/examples/namespaced/request-delete-remove.yaml
+++ b/examples/namespaced/request-delete-remove.yaml
@@ -4,7 +4,8 @@ metadata:
   name: manage-user-delete-remove-e2e
   namespace: default
   annotations:
-    uptest.upbound.io/post-assert-hook: "../../test/hooks/verify-remove-on-delete.sh"
+    uptest.upbound.io/pre-delete-hook: "./test/hooks/verify-remove-on-delete.sh"
+    uptest.upbound.io/conditions: "Synced"
 spec:
   forProvider:
     insecureSkipTLSVerify: true

--- a/examples/namespaced/request-delete-remove.yaml
+++ b/examples/namespaced/request-delete-remove.yaml
@@ -1,0 +1,48 @@
+apiVersion: http.m.crossplane.io/v1alpha2
+kind: Request
+metadata:
+  name: manage-user-delete-remove-e2e
+  namespace: default
+  annotations:
+    uptest.upbound.io/post-assert-hook: "../../test/hooks/verify-remove-on-delete.sh"
+spec:
+  forProvider:
+    insecureSkipTLSVerify: true
+    waitTimeout: 5m
+    headers:
+      Content-Type:
+        - application/json
+      Authorization:
+        - "Bearer {{ auth:default:token }}"
+    payload:
+      baseUrl: http://test-server.default.svc.cluster.local/v1/users
+      body: |
+        {
+          "username": "delete_remove_e2e_user",
+          "email": "delete_remove_e2e_user@example.com",
+          "password": "delete_remove_pw_{{ user-password:default:password }}"
+        }
+    mappings:
+      - action: CREATE
+        body: |
+          {
+            username: .payload.body.username,
+            email: .payload.body.email,
+            password: .payload.body.password
+          }
+        url: .payload.baseUrl
+      - action: OBSERVE
+        url: .payload.baseUrl + "/" + (.response.body.id | tostring)
+      - action: REMOVE
+        url: .payload.baseUrl + "/" + (.response.body.id | tostring)
+    expectedResponseCheck:
+      type: CUSTOM
+      logic: |
+        if (.response.body.id != null)
+          and (.response.body.username == .payload.body.username)
+          then true
+          else false
+          end
+  providerConfigRef:
+    name: http-conf-namespaced
+    kind: ProviderConfig

--- a/examples/namespaced/request.yaml
+++ b/examples/namespaced/request.yaml
@@ -77,7 +77,7 @@ spec:
         if .response.body.password == .payload.body.password
          and .response.body.age == 25
          and .response.headers."Content-Type" == ["application/json"]
-         and .response.headers."X-Secret-Header"[0] == "{{ response-secret:default:extracted-header-data }}"
+         and .response.headers."X-Secret-Header"[0] == "{{ response-secret-namespaced:default:extracted-header-data }}"
          then true 
          else false 
          end

--- a/examples/namespaced/test/hooks/verify-remove-on-delete.sh
+++ b/examples/namespaced/test/hooks/verify-remove-on-delete.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RESOURCE_NAME="manage-user-delete-remove-e2e"
+export RESOURCE_KIND="requests.http.m.crossplane.io"
+export RESOURCE_NAMESPACE="default"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_HOOK="${SCRIPT_DIR}/../../../../test/hooks/verify-remove-on-delete.sh"
+
+exec "${ROOT_HOOK}" "$@"

--- a/examples/sample/request-delete-remove.yaml
+++ b/examples/sample/request-delete-remove.yaml
@@ -1,0 +1,46 @@
+apiVersion: http.crossplane.io/v1alpha2
+kind: Request
+metadata:
+  name: manage-user-delete-remove-e2e-sample
+  annotations:
+    uptest.upbound.io/post-assert-hook: "../../test/hooks/verify-remove-on-delete.sh"
+spec:
+  forProvider:
+    insecureSkipTLSVerify: true
+    waitTimeout: 5m
+    headers:
+      Content-Type:
+        - application/json
+      Authorization:
+        - "Bearer {{ auth:default:token }}"
+    payload:
+      baseUrl: http://test-server.default.svc.cluster.local/v1/users
+      body: |
+        {
+          "username": "delete_remove_e2e_user_sample",
+          "email": "delete_remove_e2e_user_sample@example.com",
+          "password": "delete_remove_pw_{{ user-password:crossplane-system:password }}"
+        }
+    mappings:
+      - action: CREATE
+        body: |
+          {
+            username: .payload.body.username,
+            email: .payload.body.email,
+            password: .payload.body.password
+          }
+        url: .payload.baseUrl
+      - action: OBSERVE
+        url: .payload.baseUrl + "/" + (.response.body.id | tostring)
+      - action: REMOVE
+        url: .payload.baseUrl + "/" + (.response.body.id | tostring)
+    expectedResponseCheck:
+      type: CUSTOM
+      logic: |
+        if (.response.body.id != null)
+          and (.response.body.username == .payload.body.username)
+          then true
+          else false
+          end
+  providerConfigRef:
+    name: http-conf

--- a/examples/sample/request-delete-remove.yaml
+++ b/examples/sample/request-delete-remove.yaml
@@ -3,7 +3,8 @@ kind: Request
 metadata:
   name: manage-user-delete-remove-e2e-sample
   annotations:
-    uptest.upbound.io/post-assert-hook: "../../test/hooks/verify-remove-on-delete.sh"
+    uptest.upbound.io/pre-delete-hook: "./test/hooks/verify-remove-on-delete.sh"
+    uptest.upbound.io/conditions: "Synced"
 spec:
   forProvider:
     insecureSkipTLSVerify: true

--- a/examples/sample/test/hooks/verify-remove-on-delete.sh
+++ b/examples/sample/test/hooks/verify-remove-on-delete.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RESOURCE_NAME="manage-user-delete-remove-e2e-sample"
+export RESOURCE_KIND="requests.http.crossplane.io"
+export RESOURCE_NAMESPACE=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_HOOK="${SCRIPT_DIR}/../../../../test/hooks/verify-remove-on-delete.sh"
+
+exec "${ROOT_HOOK}" "$@"

--- a/internal/controller/cluster/request/request.go
+++ b/internal/controller/cluster/request/request.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
-	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -182,13 +181,6 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	cr, ok := mg.(*v1alpha2.Request)
 	if !ok {
 		return managed.ExternalObservation{}, errors.New(errNotRequest)
-	}
-
-	if meta.WasDeleted(mg) {
-		c.logger.Debug("Request is being deleted, skipping observation")
-		return managed.ExternalObservation{
-			ResourceExists: true,
-		}, nil
 	}
 
 	svcCtx := service.NewServiceContext(ctx, c.localKube, c.logger, c.http, c.tlsConfigData)

--- a/internal/controller/cluster/request/request.go
+++ b/internal/controller/cluster/request/request.go
@@ -187,7 +187,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	if meta.WasDeleted(mg) {
 		c.logger.Debug("Request is being deleted, skipping observation")
 		return managed.ExternalObservation{
-			ResourceExists: false,
+			ResourceExists: true,
 		}, nil
 	}
 

--- a/internal/controller/cluster/request/request_test.go
+++ b/internal/controller/cluster/request/request_test.go
@@ -1013,6 +1013,7 @@ func TestObserve_DeletionMonitoring(t *testing.T) {
 					},
 				},
 				localKube: &test.MockClient{
+					MockGet:          test.NewMockGetFn(nil),
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				mg: httpRequestWithDeletion(),

--- a/internal/controller/cluster/request/request_test.go
+++ b/internal/controller/cluster/request/request_test.go
@@ -1002,11 +1002,24 @@ func TestObserve_DeletionMonitoring(t *testing.T) {
 		{
 			name: "ResourceBeingDeleted",
 			args: args{
+				http: &MockHttpClient{
+					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+						return httpClient.HttpDetails{
+							HttpResponse: httpClient.HttpResponse{
+								StatusCode: 200,
+								Body:       `{"id": "123"}`,
+							},
+						}, nil
+					},
+				},
+				localKube: &test.MockClient{
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+				},
 				mg: httpRequestWithDeletion(),
 			},
 			want: want{
 				obs: managed.ExternalObservation{
-					ResourceExists: false,
+					ResourceExists: true,
 				},
 			},
 		},

--- a/internal/controller/namespaced/request/request.go
+++ b/internal/controller/namespaced/request/request.go
@@ -205,7 +205,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	if meta.WasDeleted(mg) {
 		c.logger.Debug("Request is being deleted, skipping observation")
 		return managed.ExternalObservation{
-			ResourceExists: false,
+			ResourceExists: true,
 		}, nil
 	}
 

--- a/internal/controller/namespaced/request/request.go
+++ b/internal/controller/namespaced/request/request.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
-	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -200,13 +199,6 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	cr, ok := mg.(*v1alpha2.Request)
 	if !ok {
 		return managed.ExternalObservation{}, errors.New(errNotRequest)
-	}
-
-	if meta.WasDeleted(mg) {
-		c.logger.Debug("Request is being deleted, skipping observation")
-		return managed.ExternalObservation{
-			ResourceExists: true,
-		}, nil
 	}
 
 	svcCtx := service.NewServiceContext(ctx, c.localKube, c.logger, c.http, c.tlsConfigData)

--- a/internal/controller/namespaced/request/request_test.go
+++ b/internal/controller/namespaced/request/request_test.go
@@ -204,7 +204,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				obs: managed.ExternalObservation{
-					ResourceExists: true,
+					ResourceExists: false,
 				},
 			},
 		},
@@ -1001,6 +1001,7 @@ func TestObserve_DeletionMonitoring(t *testing.T) {
 					},
 				},
 				localKube: &test.MockClient{
+					MockGet:          test.NewMockGetFn(nil),
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				mg: httpNamespacedRequestWithDeletion(),

--- a/internal/controller/namespaced/request/request_test.go
+++ b/internal/controller/namespaced/request/request_test.go
@@ -204,7 +204,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				obs: managed.ExternalObservation{
-					ResourceExists: false,
+					ResourceExists: true,
 				},
 			},
 		},
@@ -990,11 +990,24 @@ func TestObserve_DeletionMonitoring(t *testing.T) {
 		{
 			name: "ResourceBeingDeleted",
 			args: args{
+				http: &MockHttpClient{
+					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+						return httpClient.HttpDetails{
+							HttpResponse: httpClient.HttpResponse{
+								StatusCode: 200,
+								Body:       `{"id": "123"}`,
+							},
+						}, nil
+					},
+				},
+				localKube: &test.MockClient{
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+				},
 				mg: httpNamespacedRequestWithDeletion(),
 			},
 			want: want{
 				obs: managed.ExternalObservation{
-					ResourceExists: false,
+					ResourceExists: true,
 				},
 			},
 		},

--- a/test/hooks/verify-remove-on-delete.sh
+++ b/test/hooks/verify-remove-on-delete.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-remove-on-delete.sh
+# Uptest post-assert hook: validate Request REMOVE (DELETE) is sent on resource deletion
+
+RESOURCE_NAME=${RESOURCE_NAME:-${TEST_NAME:-manage-user-delete-remove-e2e}}
+RESOURCE_NAMESPACE=${RESOURCE_NAMESPACE:-${TEST_NAMESPACE:-default}}
+RESOURCE_KIND=${RESOURCE_KIND:-requests.http.m.crossplane.io}
+TIMEOUT=${VERIFY_REMOVE_TIMEOUT:-120}
+LOG_NAMESPACE=${LOG_NAMESPACE:-default}
+LOG_SELECTOR=${LOG_SELECTOR:-app=test-server}
+LOG_TAIL=${LOG_TAIL:-300}
+
+resource_exists() {
+  local kind="$1"
+  local name="$2"
+  local namespace="${3:-}"
+
+  if [[ "$kind" == "requests.http.crossplane.io" ]]; then
+    kubectl get "$kind" "$name" >/dev/null 2>&1
+    return
+  fi
+
+  kubectl get "$kind" "$name" -n "$namespace" >/dev/null 2>&1
+}
+
+to_epoch() {
+  local ts="$1"
+  date -u -d "$ts" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null || echo ""
+}
+
+log_line_epoch() {
+  local line="$1"
+  local ts
+  ts=$(echo "$line" | awk '{print $1" "$2}')
+  date -u -d "$ts" +%s 2>/dev/null || date -u -j -f "%Y/%m/%d %H:%M:%S" "$ts" +%s 2>/dev/null || echo ""
+}
+
+print_diagnostics() {
+  echo ""
+  echo "=== Diagnostics ==="
+  if kubectl get "$RESOURCE_KIND" "$RESOURCE_NAME" $RR_NS_ARG >/dev/null 2>&1; then
+    echo "Resource still exists; describe output:"
+    kubectl describe "$RESOURCE_KIND" "$RESOURCE_NAME" $RR_NS_ARG || true
+  else
+    echo "Resource no longer exists."
+  fi
+  if [[ -n "${TEST_SERVER_POD:-}" ]]; then
+    echo "Recent test-server logs (tail ${LOG_TAIL}):"
+    kubectl logs -n "$LOG_NAMESPACE" "$TEST_SERVER_POD" --tail="$LOG_TAIL" 2>/dev/null || true
+  else
+    echo "No test-server pod discovered."
+  fi
+}
+
+if ! resource_exists "$RESOURCE_KIND" "$RESOURCE_NAME" "$RESOURCE_NAMESPACE"; then
+  for kind in "requests.http.crossplane.io" "requests.http.m.crossplane.io"; do
+    if resource_exists "$kind" "$RESOURCE_NAME" "$RESOURCE_NAMESPACE"; then
+      RESOURCE_KIND="$kind"
+      break
+    fi
+  done
+fi
+
+if [[ "$RESOURCE_KIND" == "requests.http.crossplane.io" ]]; then
+  RESOURCE_NAMESPACE=""
+fi
+
+if [[ -n "${RESOURCE_NAMESPACE:-}" ]]; then
+  RR_NS_ARG="-n $RESOURCE_NAMESPACE"
+else
+  RR_NS_ARG=""
+fi
+
+echo "========================================="
+echo "verify-remove-on-delete: validating DELETE on Request deletion"
+echo "Resource: $RESOURCE_KIND/$RESOURCE_NAME (namespace: ${RESOURCE_NAMESPACE:-<cluster-scoped>})"
+echo "========================================="
+
+if ! kubectl get "$RESOURCE_KIND" "$RESOURCE_NAME" $RR_NS_ARG >/dev/null 2>&1; then
+  echo "FAIL: Resource not found: $RESOURCE_KIND/$RESOURCE_NAME"
+  exit 1
+fi
+
+RESPONSE_BODY=$(kubectl get "$RESOURCE_KIND" "$RESOURCE_NAME" $RR_NS_ARG -o jsonpath='{.status.response.body}' 2>/dev/null || echo "")
+if [[ -z "$RESPONSE_BODY" ]]; then
+  echo "FAIL: status.response.body is empty; cannot derive external id"
+  print_diagnostics
+  exit 2
+fi
+
+if ! echo "$RESPONSE_BODY" | jq empty >/dev/null 2>&1; then
+  echo "FAIL: status.response.body is not valid JSON"
+  echo "Body: $RESPONSE_BODY"
+  print_diagnostics
+  exit 3
+fi
+
+USER_ID=$(echo "$RESPONSE_BODY" | jq -r '.id // empty')
+if [[ -z "$USER_ID" || "$USER_ID" == "null" ]]; then
+  echo "FAIL: Could not extract .id from status.response.body"
+  echo "Body: $RESPONSE_BODY"
+  print_diagnostics
+  exit 4
+fi
+
+TEST_START_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+TEST_START_EPOCH=$(to_epoch "$TEST_START_ISO")
+echo "Start time (UTC): $TEST_START_ISO (epoch: $TEST_START_EPOCH)"
+echo "Derived external user id: $USER_ID"
+
+TEST_SERVER_POD=$(kubectl get pods -n "$LOG_NAMESPACE" -l "$LOG_SELECTOR" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [[ -z "$TEST_SERVER_POD" ]]; then
+  echo "FAIL: Could not find test-server pod in namespace '$LOG_NAMESPACE' with selector '$LOG_SELECTOR'"
+  print_diagnostics
+  exit 5
+fi
+echo "Using test-server pod: $TEST_SERVER_POD"
+
+echo "Deleting resource..."
+kubectl delete "$RESOURCE_KIND" "$RESOURCE_NAME" $RR_NS_ARG --wait=false >/dev/null
+
+echo "Waiting for resource deletion (timeout: ${TIMEOUT}s)..."
+if ! kubectl wait --for=delete "$RESOURCE_KIND/$RESOURCE_NAME" $RR_NS_ARG --timeout="${TIMEOUT}s" >/dev/null 2>&1; then
+  echo "FAIL: Resource was not deleted within timeout"
+  print_diagnostics
+  exit 6
+fi
+echo "PASS: Resource deletion observed"
+
+EXPECTED_PATH="/v1/users/$USER_ID"
+echo "Checking test-server logs for provider DELETE to $EXPECTED_PATH ..."
+
+FOUND=0
+MATCHED_LINES=""
+LOGS=$(kubectl logs -n "$LOG_NAMESPACE" "$TEST_SERVER_POD" 2>/dev/null || echo "")
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  line_epoch=$(log_line_epoch "$line")
+  if [[ -z "$line_epoch" || -z "$TEST_START_EPOCH" ]]; then
+    continue
+  fi
+  if [[ "$line_epoch" -lt "$TEST_START_EPOCH" ]]; then
+    continue
+  fi
+  if echo "$line" | grep -q "\\[DELETE\\] $EXPECTED_PATH" && echo "$line" | grep -q "Go-http-client"; then
+    FOUND=1
+    MATCHED_LINES="${MATCHED_LINES}${line}"$'\n'
+  fi
+done <<< "$LOGS"
+
+if [[ "$FOUND" -ne 1 ]]; then
+  echo "FAIL: No provider-origin DELETE log line found for $EXPECTED_PATH after test start"
+  print_diagnostics
+  exit 7
+fi
+
+echo "PASS: Found provider-origin DELETE log line(s):"
+echo "$MATCHED_LINES"
+echo "verify-remove-on-delete: success"

--- a/test/hooks/verify-remove-on-delete.sh
+++ b/test/hooks/verify-remove-on-delete.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # verify-remove-on-delete.sh
 # Uptest post-assert hook: validate Request REMOVE (DELETE) is sent on resource deletion
 
-RESOURCE_NAME=${RESOURCE_NAME:-${TEST_NAME:-manage-user-delete-remove-e2e}}
+RESOURCE_NAME=${RESOURCE_NAME:-${TEST_NAME:-}}
 RESOURCE_NAMESPACE=${RESOURCE_NAMESPACE:-${TEST_NAMESPACE:-default}}
 RESOURCE_KIND=${RESOURCE_KIND:-requests.http.m.crossplane.io}
 TIMEOUT=${VERIFY_REMOVE_TIMEOUT:-120}
@@ -77,6 +77,11 @@ echo "========================================="
 echo "verify-remove-on-delete: validating DELETE on Request deletion"
 echo "Resource: $RESOURCE_KIND/$RESOURCE_NAME (namespace: ${RESOURCE_NAMESPACE:-<cluster-scoped>})"
 echo "========================================="
+
+if [[ -z "$RESOURCE_NAME" ]]; then
+  echo "FAIL: RESOURCE_NAME is empty; set RESOURCE_NAME explicitly in uptest.upbound.io/post-assert-hook"
+  exit 1
+fi
 
 if ! kubectl get "$RESOURCE_KIND" "$RESOURCE_NAME" $RR_NS_ARG >/dev/null 2>&1; then
   echo "FAIL: Resource not found: $RESOURCE_KIND/$RESOURCE_NAME"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description
This PR fixes a regression where `Request` resources did not execute `REMOVE` during deletion, and adds end-to-end coverage to prevent recurrence.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
### What changed
1. Updated Request deletion observe behavior in both cluster-scoped and namespaced controllers so deletion flow can proceed correctly.
2. Updated/added unit tests around deletion-monitoring behavior.
3. Added e2e coverage for REMOVE-on-delete:
    - Namespaced and clustered example and hook integration.
    - Added hook logic to support both namespaced and cluster-scoped `Request` resources.

Fixes #161 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
