### PR TITLE
fix(http-client): reuse http.Transport to prevent ephemeral port exhaustion

### DIFF
--- a/internal/clients/http/client.go
+++ b/internal/clients/http/client.go
@@ -3,12 +3,15 @@ package http
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/crossplane-contrib/provider-http/apis/interfaces"
@@ -18,6 +21,12 @@ import (
 const (
 	authKey = "Authorization"
 )
+
+// httpClientCache is a process-level cache of *http.Client instances keyed by
+// a hash of their TLS configuration + timeout. Because NewClient is called on
+// every reconcile, the cache must outlive individual client instances to
+// achieve cross-reconcile connection reuse.
+var httpClientCache sync.Map
 
 // TLSConfigData contains the TLS configuration data loaded from secrets or inline.
 type TLSConfigData struct {
@@ -115,28 +124,21 @@ func (hc *client) SendRequest(ctx context.Context, method string, url string, bo
 		request.Header[authKey] = []string{hc.authorizationToken}
 	}
 
-	// Build TLS configuration
-	tlsConfig, err := buildTLSConfig(tlsConfigData)
-	if err != nil {
-		return HttpDetails{
-			HttpRequest: requestDetails,
-		}, fmt.Errorf("failed to build TLS config: %w", err)
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-			Proxy:           http.ProxyFromEnvironment, // Use proxy settings from environment
-		},
-		Timeout: hc.timeout,
-	}
-
-	response, err := client.Do(request)
+	// Look up or create a cached http.Client for this TLS + timeout combination.
+	httpCl, err := getOrCreateHTTPClient(hc.timeout, tlsConfigData)
 	if err != nil {
 		return HttpDetails{
 			HttpRequest: requestDetails,
 		}, err
 	}
+
+	response, err := httpCl.Do(request)
+	if err != nil {
+		return HttpDetails{
+			HttpRequest: requestDetails,
+		}, err
+	}
+	defer func() { _ = response.Body.Close() }()
 
 	responsebody, err := io.ReadAll(response.Body)
 	if err != nil {
@@ -149,13 +151,6 @@ func (hc *client) SendRequest(ctx context.Context, method string, url string, bo
 		Body:       string(responsebody),
 		Headers:    response.Header,
 		StatusCode: response.StatusCode,
-	}
-
-	err = response.Body.Close()
-	if err != nil {
-		return HttpDetails{
-			HttpRequest: requestDetails,
-		}, err
 	}
 
 	hc.log.Info(fmt.Sprint("http request sent: ", toJSON(requestDetails)))
@@ -173,6 +168,54 @@ func NewClient(log logging.Logger, timeout time.Duration, authorizationToken str
 		timeout:            timeout,
 		authorizationToken: authorizationToken,
 	}, nil
+}
+
+// getOrCreateHTTPClient returns a cached http.Client for the given timeout and
+// TLS configuration, creating one if it doesn't exist yet. The cache is
+// process-level so clients are reused across reconcile cycles.
+func getOrCreateHTTPClient(timeout time.Duration, tlsData *TLSConfigData) (*http.Client, error) {
+	key := httpClientKey(timeout, tlsData)
+
+	if cached, ok := httpClientCache.Load(key); ok {
+		return cached.(*http.Client), nil
+	}
+
+	tlsConfig, err := buildTLSConfig(tlsData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
+	httpCl := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+			Proxy:           http.ProxyFromEnvironment,
+		},
+		Timeout: timeout,
+	}
+
+	actual, _ := httpClientCache.LoadOrStore(key, httpCl)
+	return actual.(*http.Client), nil
+}
+
+// httpClientKey produces a cache key from timeout and TLS config content so
+// that identical configurations share a single http.Client/Transport.
+func httpClientKey(timeout time.Duration, data *TLSConfigData) string {
+	h := sha256.New()
+	// Include timeout in the key so different timeouts get different clients.
+	_, _ = fmt.Fprintf(h, "%d\x00", timeout)
+	if data != nil {
+		h.Write(data.CABundle)
+		h.Write([]byte{0})
+		h.Write(data.ClientCert)
+		h.Write([]byte{0})
+		h.Write(data.ClientKey)
+		if data.InsecureSkipVerify {
+			h.Write([]byte{1})
+		} else {
+			h.Write([]byte{0})
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // toJSON converts the request to a JSON string.

--- a/internal/clients/http/client_test.go
+++ b/internal/clients/http/client_test.go
@@ -1095,6 +1095,80 @@ func TestBuildTLSConfigNilSafety(t *testing.T) {
 	})
 }
 
+func TestHTTPClientCacheReuse(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	tlsConfig := &TLSConfigData{InsecureSkipVerify: true}
+
+	// Two separate client instances (simulating two reconcile cycles) should
+	// get the same cached http.Client for the same TLS config + timeout.
+	c1, _ := NewClient(logging.NewNopLogger(), 30*time.Second, "")
+	c2, _ := NewClient(logging.NewNopLogger(), 30*time.Second, "")
+
+	for i := 0; i < 10; i++ {
+		c := c1
+		if i%2 == 1 {
+			c = c2
+		}
+		result, err := c.SendRequest(
+			context.Background(),
+			http.MethodGet,
+			server.URL,
+			Data{Encrypted: "", Decrypted: ""},
+			Data{Encrypted: map[string][]string{}, Decrypted: map[string][]string{}},
+			tlsConfig,
+		)
+		if err != nil {
+			t.Fatalf("SendRequest #%d: unexpected error: %v", i, err)
+		}
+		if result.HttpResponse.StatusCode != http.StatusOK {
+			t.Fatalf("SendRequest #%d: statusCode = %v, want 200", i, result.HttpResponse.StatusCode)
+		}
+	}
+}
+
+func TestTransportReuse(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	c, err := NewClient(logging.NewNopLogger(), 30*time.Second, "")
+	if err != nil {
+		t.Fatalf("NewClient(...): unexpected error: %v", err)
+	}
+
+	// Send multiple requests on the same client — all should succeed,
+	// proving transport/connection reuse works.
+	for i := 0; i < 50; i++ {
+		result, err := c.SendRequest(
+			context.Background(),
+			http.MethodGet,
+			server.URL,
+			Data{Encrypted: "", Decrypted: ""},
+			Data{Encrypted: map[string][]string{}, Decrypted: map[string][]string{}},
+			nil, // nil TLS config = use shared client
+		)
+		if err != nil {
+			t.Fatalf("SendRequest #%d: unexpected error: %v", i, err)
+		}
+		if result.HttpResponse.StatusCode != http.StatusOK {
+			t.Fatalf("SendRequest #%d: statusCode = %v, want 200", i, result.HttpResponse.StatusCode)
+		}
+	}
+
+	if requestCount != 50 {
+		t.Errorf("expected 50 requests to reach server, got %d", requestCount)
+	}
+}
+
 func TestTLSConfigInsecureSkipVerifyFlag(t *testing.T) {
 	t.Run("InsecureSkipVerifyFalseByDefault", func(t *testing.T) {
 		config := &tls.Config{}

--- a/internal/clients/http/client_test.go
+++ b/internal/clients/http/client_test.go
@@ -7,9 +7,11 @@ import (
 	"encoding/pem"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1095,78 +1097,207 @@ func TestBuildTLSConfigNilSafety(t *testing.T) {
 	})
 }
 
+// resetHTTPClientCache clears the global httpClientCache so that tests are
+// isolated from each other.
+func resetHTTPClientCache() {
+	httpClientCache.Clear()
+}
+
 func TestHTTPClientCacheReuse(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
-	}))
-	defer server.Close()
+	type pair struct {
+		timeout time.Duration
+		tls     *TLSConfigData
+	}
 
-	tlsConfig := &TLSConfigData{InsecureSkipVerify: true}
+	cases := map[string]struct {
+		a        pair
+		b        pair
+		wantSame bool
+	}{
+		"SameConfigReturnsSameClient": {
+			a:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{InsecureSkipVerify: true}},
+			b:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{InsecureSkipVerify: true}},
+			wantSame: true,
+		},
+		"NilTLSConfigReturnsSameClient": {
+			a:        pair{timeout: 30 * time.Second, tls: nil},
+			b:        pair{timeout: 30 * time.Second, tls: nil},
+			wantSame: true,
+		},
+		"DifferentTimeoutReturnsDifferentClient": {
+			a:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{InsecureSkipVerify: true}},
+			b:        pair{timeout: 10 * time.Second, tls: &TLSConfigData{InsecureSkipVerify: true}},
+			wantSame: false,
+		},
+		"NilVsNonNilTLSReturnsDifferentClient": {
+			a:        pair{timeout: 30 * time.Second, tls: nil},
+			b:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{}},
+			wantSame: false,
+		},
+		"DifferentInsecureSkipVerifyReturnsDifferentClient": {
+			a:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{InsecureSkipVerify: false}},
+			b:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{InsecureSkipVerify: true}},
+			wantSame: false,
+		},
+	}
 
-	// Two separate client instances (simulating two reconcile cycles) should
-	// get the same cached http.Client for the same TLS config + timeout.
-	c1, _ := NewClient(logging.NewNopLogger(), 30*time.Second, "")
-	c2, _ := NewClient(logging.NewNopLogger(), 30*time.Second, "")
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			resetHTTPClientCache()
 
-	for i := 0; i < 10; i++ {
-		c := c1
-		if i%2 == 1 {
-			c = c2
-		}
-		result, err := c.SendRequest(
-			context.Background(),
-			http.MethodGet,
-			server.URL,
-			Data{Encrypted: "", Decrypted: ""},
-			Data{Encrypted: map[string][]string{}, Decrypted: map[string][]string{}},
-			tlsConfig,
-		)
-		if err != nil {
-			t.Fatalf("SendRequest #%d: unexpected error: %v", i, err)
-		}
-		if result.HttpResponse.StatusCode != http.StatusOK {
-			t.Fatalf("SendRequest #%d: statusCode = %v, want 200", i, result.HttpResponse.StatusCode)
-		}
+			cl1, err := getOrCreateHTTPClient(tc.a.timeout, tc.a.tls)
+			if err != nil {
+				t.Fatalf("getOrCreateHTTPClient(a): %v", err)
+			}
+			if cl1 == nil {
+				t.Fatal("getOrCreateHTTPClient(a): returned nil")
+			}
+			if cl1.Timeout != tc.a.timeout {
+				t.Errorf("cl1.Timeout = %v, want %v", cl1.Timeout, tc.a.timeout)
+			}
+
+			cl2, err := getOrCreateHTTPClient(tc.b.timeout, tc.b.tls)
+			if err != nil {
+				t.Fatalf("getOrCreateHTTPClient(b): %v", err)
+			}
+			if cl2 == nil {
+				t.Fatal("getOrCreateHTTPClient(b): returned nil")
+			}
+			if cl2.Timeout != tc.b.timeout {
+				t.Errorf("cl2.Timeout = %v, want %v", cl2.Timeout, tc.b.timeout)
+			}
+
+			if tc.wantSame && cl1 != cl2 {
+				t.Error("expected same *http.Client from cache, got different pointers")
+			}
+			if !tc.wantSame && cl1 == cl2 {
+				t.Error("expected different *http.Client instances, got same pointer")
+			}
+		})
+	}
+}
+
+func TestHTTPClientKeyDifferentiation(t *testing.T) {
+	type pair struct {
+		timeout time.Duration
+		tls     *TLSConfigData
+	}
+
+	cases := map[string]struct {
+		a        pair
+		b        pair
+		wantSame bool
+	}{
+		"IdenticalConfigsSameKey": {
+			a:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{InsecureSkipVerify: true}},
+			b:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{InsecureSkipVerify: true}},
+			wantSame: true,
+		},
+		"DifferentCABundleDifferentKey": {
+			a:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{CABundle: []byte("ca-a")}},
+			b:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{CABundle: []byte("ca-b")}},
+			wantSame: false,
+		},
+		"DifferentClientCertDifferentKey": {
+			a:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{ClientCert: []byte("cert-a")}},
+			b:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{ClientCert: []byte("cert-b")}},
+			wantSame: false,
+		},
+		"DifferentClientKeyDifferentKey": {
+			a:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{ClientKey: []byte("key-a")}},
+			b:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{ClientKey: []byte("key-b")}},
+			wantSame: false,
+		},
+		"NilVsEmptyTLSDifferentKey": {
+			a:        pair{timeout: 30 * time.Second, tls: nil},
+			b:        pair{timeout: 30 * time.Second, tls: &TLSConfigData{}},
+			wantSame: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			keyA := httpClientKey(tc.a.timeout, tc.a.tls)
+			keyB := httpClientKey(tc.b.timeout, tc.b.tls)
+
+			if keyA == "" {
+				t.Fatal("httpClientKey(a) returned empty string")
+			}
+			if tc.wantSame && keyA != keyB {
+				t.Errorf("expected same key, got %q vs %q", keyA, keyB)
+			}
+			if !tc.wantSame && keyA == keyB {
+				t.Errorf("expected different keys, got identical %q", keyA)
+			}
+		})
 	}
 }
 
 func TestTransportReuse(t *testing.T) {
-	requestCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+	resetHTTPClientCache()
+
+	var connCount int32
+	var requestCount int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			atomic.AddInt32(&connCount, 1)
+		}
+	}
+	server.Start()
 	defer server.Close()
 
-	c, err := NewClient(logging.NewNopLogger(), 30*time.Second, "")
+	// Two separate client instances simulate consecutive reconcile cycles.
+	// With transport caching, both should share the same underlying
+	// http.Client and TCP connection pool.
+	c1, err := NewClient(logging.NewNopLogger(), 30*time.Second, "")
 	if err != nil {
-		t.Fatalf("NewClient(...): unexpected error: %v", err)
+		t.Fatalf("NewClient (1st): %v", err)
+	}
+	c2, err := NewClient(logging.NewNopLogger(), 30*time.Second, "")
+	if err != nil {
+		t.Fatalf("NewClient (2nd): %v", err)
 	}
 
-	// Send multiple requests on the same client — all should succeed,
-	// proving transport/connection reuse works.
-	for i := 0; i < 50; i++ {
-		result, err := c.SendRequest(
+	const totalRequests = 50
+	for i := 0; i < totalRequests; i++ {
+		cl := c1
+		if i%2 == 1 {
+			cl = c2
+		}
+		result, err := cl.SendRequest(
 			context.Background(),
 			http.MethodGet,
 			server.URL,
 			Data{Encrypted: "", Decrypted: ""},
 			Data{Encrypted: map[string][]string{}, Decrypted: map[string][]string{}},
-			nil, // nil TLS config = use shared client
+			nil,
 		)
 		if err != nil {
-			t.Fatalf("SendRequest #%d: unexpected error: %v", i, err)
+			t.Fatalf("SendRequest #%d: %v", i, err)
 		}
 		if result.HttpResponse.StatusCode != http.StatusOK {
-			t.Fatalf("SendRequest #%d: statusCode = %v, want 200", i, result.HttpResponse.StatusCode)
+			t.Fatalf("SendRequest #%d: status = %d, want %d", i, result.HttpResponse.StatusCode, http.StatusOK)
 		}
 	}
 
-	if requestCount != 50 {
-		t.Errorf("expected 50 requests to reach server, got %d", requestCount)
+	conns := atomic.LoadInt32(&connCount)
+	reqs := atomic.LoadInt32(&requestCount)
+
+	if reqs != totalRequests {
+		t.Errorf("server received %d requests, want %d", reqs, totalRequests)
 	}
+	// Without transport reuse we'd see ~50 TCP connections (one per
+	// SendRequest). With reuse, keep-alive ensures very few connections
+	// (typically 1-2).
+	if conns > 5 {
+		t.Errorf("expected connection reuse (<=5 TCP connections for %d requests), got %d", totalRequests, conns)
+	}
+	t.Logf("%d requests served over %d TCP connection(s)", totalRequests, conns)
 }
 
 func TestTLSConfigInsecureSkipVerifyFlag(t *testing.T) {


### PR DESCRIPTION

Use a process-level cache of http.Client instances keyed by TLS config and timeout. This ensures connection pooling across reconcile cycles, preventing TCP connection leaks that exhaust the ephemeral port range.

- Cache http.Client/Transport in a package-level sync.Map keyed by SHA-256 of TLS config + timeout
- Fix response.Body.Close() ordering with defer to prevent leaks if io.ReadAll() fails
- All TLS configurations (plain, InsecureSkipVerify, custom CA/certs) are cached uniformly

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR fixes ephemeral TCP port exhaustion caused by creating a new `http.Client` and `http.Transport` on every `SendRequest()` call. Since `NewClient()` is called per-reconcile via `Connect()`, any per-instance state is destroyed each cycle, so transports were never reused — leaving idle connections in TCP TIME_WAIT until the entire ephemeral port range was exhausted.
                                                                                                                                  
  **What changed:**                                                                                                                                                                                                                                                                                                                                                                                       
  - Introduced a process-level `sync.Map` cache (`httpClientCache`) that stores `http.Client` instances keyed by a SHA-256 hash of their TLS configuration + timeout. This ensures transport reuse across reconcile cycles for all connection types (plain HTTP, InsecureSkipVerify, custom CA bundles, client certificates).                                                                             
  - Fixed `response.Body.Close()` to use `defer` immediately after the response is received, preventing body/connection leaks if `io.ReadAll()` fails.                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                          
  **Reviewers should note:**                                                                                                             
  - The cache is intentionally unbounded — in practice, the number of distinct TLS config + timeout combinations is very small (typically 1-3). Adding eviction would add complexity with no real benefit.
  - `LoadOrStore` is used instead of `Load`/`Store` to handle the race where two goroutines create clients for the same key simultaneously — only one wins, the other is discarded.
  - The `Client` interface and all external behavior are unchanged. This is a purely internal optimization.

  **Production context:** This was observed on a production cluster where a single provider-http pod accumulated 28,280 open sockets, exhausting the Linux ephemeral port range (32768-60999) and causing `dial tcp: connect: cannot assign requested address` errors at ~16/min.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

The fix was validated at multiple levels:                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                        
**Unit tests (new):**                                                                                                                                                                                                                                                                                                                                                                                   
- `TestHTTPClientCacheReuse`: Two separate `client` instances (simulating consecutive reconcile cycles) with identical TLS config receive the same cached `http.Client` from the process-level `sync.Map`, confirming cross-reconcile transport reuse.                                                                                                                                                  
- `TestTransportReuse`: Sends 50 sequential HTTP requests through a single client instance and verifies all succeed — proving connection reuse and no port leak under sustained load.

**Existing tests (unchanged, all pass):**
- `TestSendRequest` covers GET, POST, custom headers, auth token, InsecureSkipVerify, and invalid TLS — all go through the new cache path.
- `TestSendRequestIntegration` performs end-to-end requests against `httptest.NewTLSServer` with real TLS handshakes.
- `TestHTTPClientConfiguration` confirms timeout propagation and proxy settings are preserved on cached clients.
- `TestBuildTLSConfig` (10 sub-tests) validates all TLS config permutations (nil, empty, CA bundle, client certs, InsecureSkipVerify).

**CI gate:**
- `make reviewable test` passes (golangci-lint, go vet, all project tests).

[contribution process]: https://git.io/fj2m9
