### PR TITLE
fix(secret-patcher): mask JSON-object values in status when server key order differs

### DIFF
--- a/internal/data-patcher/secret_patcher.go
+++ b/internal/data-patcher/secret_patcher.go
@@ -175,9 +175,17 @@ func replaceSensitiveValues(data *httpClient.HttpResponse, secret *corev1.Secret
 
 	placeholder := fmt.Sprintf("{{%s:%s:%s}}", secret.Name, secret.Namespace, secretKey)
 
-	// For JSON objects, replace the entire JSON object in the response
+	// For JSON objects, replace the entire JSON object in the response.
+	// valueToPatch is produced by json.Marshal which sorts keys alphabetically,
+	// while data.Body preserves the server's key ordering, so a substring match
+	// on data.Body fails. Walk the parsed body and replace any subtree whose
+	// canonical JSON form equals valueToPatch.
 	if isJSONObject(*valueToPatch) {
-		data.Body = strings.ReplaceAll(data.Body, *valueToPatch, fmt.Sprintf("\"%s\"", placeholder))
+		if replaced, ok := replaceJSONObjectInBody(data.Body, *valueToPatch, placeholder); ok {
+			data.Body = replaced
+		} else {
+			data.Body = strings.ReplaceAll(data.Body, *valueToPatch, fmt.Sprintf("\"%s\"", placeholder))
+		}
 	} else {
 		// For simple values, use the existing logic with quoted replacement
 		quotedValue := fmt.Sprintf("\"%s\"", *valueToPatch)
@@ -191,6 +199,52 @@ func replaceSensitiveValues(data *httpClient.HttpResponse, secret *corev1.Secret
 			headersList[i] = strings.ReplaceAll(header, *valueToPatch, placeholder)
 		}
 	}
+}
+
+// replaceJSONObjectInBody parses body as JSON, replaces any subtree whose
+// canonical (key-sorted) JSON form matches canonicalValue with the placeholder,
+// and returns the re-marshaled body. Returns ok=false if body is not valid JSON
+// or no match was found, leaving the caller to fall back to substring replace.
+func replaceJSONObjectInBody(body, canonicalValue, placeholder string) (string, bool) {
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return "", false
+	}
+	replaced, ok := walkAndReplace(parsed, canonicalValue, placeholder)
+	if !ok {
+		return "", false
+	}
+	out, err := json.Marshal(replaced)
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}
+
+// walkAndReplace traverses v and substitutes the first subtree whose
+// canonical JSON form equals target with placeholder. Returns the (possibly
+// updated) tree and whether a replacement occurred.
+func walkAndReplace(v interface{}, target, placeholder string) (interface{}, bool) {
+	if obj, isObj := v.(map[string]interface{}); isObj {
+		if marshaled, err := json.Marshal(obj); err == nil && string(marshaled) == target {
+			return placeholder, true
+		}
+		for k, child := range obj {
+			if newChild, ok := walkAndReplace(child, target, placeholder); ok {
+				obj[k] = newChild
+				return obj, true
+			}
+		}
+	}
+	if arr, isArr := v.([]interface{}); isArr {
+		for i, child := range arr {
+			if newChild, ok := walkAndReplace(child, target, placeholder); ok {
+				arr[i] = newChild
+				return arr, true
+			}
+		}
+	}
+	return v, false
 }
 
 // isJSONObject checks if a string is a valid JSON object (starts with '{' and ends with '}')

--- a/internal/data-patcher/secret_patcher_test.go
+++ b/internal/data-patcher/secret_patcher_test.go
@@ -324,7 +324,39 @@ func TestReplaceSensitiveValues(t *testing.T) {
 				valueToPatch: ptr.To(`{"client_id":"test_client","client_secret":"test_secret"}`),
 			},
 			want: want{
-				body: `{"credentials": "{{my-secret:default:creds}}", "other": "data"}`,
+				// Body is re-marshaled to normalize key ordering, so insignificant
+				// whitespace is collapsed.
+				body: `{"credentials":"{{my-secret:default:creds}}","other":"data"}`,
+				headers: map[string][]string{
+					"Content-Type": {"application/json"},
+				},
+			},
+		},
+		"ShouldReplaceJSONObjectInBodyWhenServerKeyOrderDiffersFromValueToPatch": {
+			// Regression test for issue #169: extractValueToPatch produces JSON with
+			// json.Marshal which sorts keys alphabetically, while the response body
+			// preserves the server's key ordering. A plain strings.ReplaceAll on body
+			// fails to match, leaving the sensitive object unmasked in status.
+			args: args{
+				data: &httpClient.HttpResponse{
+					// Server returns keys in non-alphabetical order ("token" before "expires").
+					Body: `{"body":{"status":{"token":"abc123","expires":3600}},"statusCode":200}`,
+					Headers: map[string][]string{
+						"Content-Type": {"application/json"},
+					},
+				},
+				secret: &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-secret",
+						Namespace: "default",
+					},
+				},
+				secretKey: "auth",
+				// Same content as in body but key-sorted, as json.Marshal would emit it.
+				valueToPatch: ptr.To(`{"expires":3600,"token":"abc123"}`),
+			},
+			want: want{
+				body: `{"body":{"status":"{{my-secret:default:auth}}"},"statusCode":200}`,
 				headers: map[string][]string{
 					"Content-Type": {"application/json"},
 				},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes #169

When \`secretInjectionConfigs.responseJQ\` selects a JSON object (e.g. \`.body\`), the value is correctly stored in the referenced Secret but the sensitive object remains visible in the \`DisposableRequest\` status, \`replaceSensitiveValues\` never replaces it with the \`{{secret-name:namespace:key}}\` placeholder.

\`extractValueToPatch\` produces the value via \`json.Marshal\`, which sorts keys alphabetically, while \`data.Body\` preserves the server's original key ordering. \`strings.ReplaceAll\` does an exact substring match, so the two strings rarely match in practice and the replacement is silently skipped.

Walk the parsed body and replace the first subtree whose canonical (key-sorted) JSON form equals the extracted value with the placeholder. Fall back to the existing substring replacement when the body is not parseable as JSON.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run \`make reviewable test\` to ensure this PR is ready for review.

### How has this code been tested

Added a regression test that mirrors the bug: response body with a nested object whose keys are in non-alphabetical order, and a \`valueToPatch\` produced by \`json.Marshal\` (key-sorted). Confirms the placeholder is now applied at the correct location. The existing \`ShouldReplaceJSONObjectInBody\` test was updated to reflect that the body is re-marshaled (insignificant whitespace is collapsed). Full \`go test ./...\` passes.

[contribution process]: https://git.io/fj2m9