### PR TITLE
fix(disposablerequest): prevent stuck external-create-pending

### DIFF
--- a/internal/controller/cluster/disposablerequest/disposablerequest.go
+++ b/internal/controller/cluster/disposablerequest/disposablerequest.go
@@ -151,6 +151,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 		WithCustomPollIntervalHook(),
 		managed.WithTimeout(timeout),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+		managed.WithDeterministicExternalName(true),
 	}
 
 	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {

--- a/internal/controller/cluster/disposablerequest/disposablerequest_test.go
+++ b/internal/controller/cluster/disposablerequest/disposablerequest_test.go
@@ -335,6 +335,42 @@ func Test_httpExternal_Observe(t *testing.T) {
 			},
 		},
 		{
+			name: "ResourceNotSyncedWithCreatePending",
+			args: args{
+				http: &MockHttpClient{},
+				localKube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				},
+				mg: &v1alpha2.DisposableRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"crossplane.io/external-create-pending": time.Now().Format(time.RFC3339),
+							"crossplane.io/external-name":           "test-request",
+						},
+					},
+					Spec: v1alpha2.DisposableRequestSpec{
+						ForProvider: v1alpha2.DisposableRequestParameters{
+							URL:    testURL,
+							Method: testMethod,
+						},
+					},
+					Status: v1alpha2.DisposableRequestStatus{
+						Synced: false,
+					},
+				},
+			},
+			want: want{
+				// ResourceExists=false when not synced, even with create-pending.
+				// This triggers the managed reconciler to re-enter Create on every
+				// loop, which is why WithDeterministicExternalName(true) is needed
+				// to prevent the reconciler from hard-stopping on ambiguous creation.
+				observation: managed.ExternalObservation{
+					ResourceExists: false,
+				},
+				err: nil,
+			},
+		},
+		{
 			name: "ResourceNotSyncedWithRetryPendingAndNextReconcileNotReached",
 			args: args{
 				http: &MockHttpClient{},

--- a/internal/controller/namespaced/disposablerequest/disposablerequest.go
+++ b/internal/controller/namespaced/disposablerequest/disposablerequest.go
@@ -153,6 +153,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 		WithCustomPollIntervalHook(),
 		managed.WithTimeout(timeout),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+		managed.WithDeterministicExternalName(true),
 	}
 
 	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {


### PR DESCRIPTION
### Description of your changes

DisposableRequest gets stuck in `external-create-pending` after recreation or failed Create calls. 

The crossplane-runtime creation guard hard-stops reconciliation because the controller does not declare its external name as deterministic.

Fix: 
- Add `managed.WithDeterministicExternalName(true)` to both cluster-scoped and namespaced DisposableRequest reconcilers
- This tells the runtime it is safe to proceed past ambiguous creation state, since the external name is always the Kubernetes object name and the HTTP call is stateless

Fixes https://github.com/crossplane-contrib/provider-http/issues/176

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Full test suite passes (23 packages)
- Added regression test `ResourceNotSyncedWithCreatePending`: verifies Observe returns `ResourceExists: false` when `Synced=false` even with `external-create-pending` annotation set
- Validated manually on GKE 1.31 with provider-http v1.0.14 and crossplane-runtime v2.0.0

[contribution process]: https://git.io/fj2m9
