### PR TITLE
fix(utils): guard nil rollbackRetriesLimit in RetriesLimitReached

### DIFF
--- a/internal/utils/retry.go
+++ b/internal/utils/retry.go
@@ -22,6 +22,9 @@ func RollBackEnabled(rollbackRetriesLimit *int32) bool {
 
 // RetriesLimitReached determines if the rollback retries limit has been reached.
 func RetriesLimitReached(statusFailed int32, rollbackRetriesLimit *int32) bool {
+	if rollbackRetriesLimit == nil {
+		return false
+	}
 	return statusFailed >= *rollbackRetriesLimit
 }
 

--- a/internal/utils/retry_test.go
+++ b/internal/utils/retry_test.go
@@ -100,6 +100,15 @@ func Test_RetriesLimitReached(t *testing.T) {
 				result: false,
 			},
 		},
+		"ResultFalseLimitNil": {
+			args: args{
+				statusFailed:         failures,
+				rollbackRetriesLimit: nil,
+			},
+			want: want{
+				result: false,
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #178

### Description of your changes

`RetriesLimitReached` dereferenced its `*int32` argument without a nil check, so the controller panicked whenever a `DisposableRequest` (cluster or namespaced) entered an error state without `rollbackRetriesLimit` set, since the field is `omitempty`. This mirrors the existing `RollBackEnabled` guard and adds a nil case to the unit table test.

### How has this code been tested

`go test ./internal/utils/` passes; the new `ResultFalseLimitNil` case fails on `main` (panics on the deref) and passes with the guard.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9