### PR TITLE
fix: URL secret patching, TLS config CEL validation, and MR metrics (#186, #164, #140)

### DIFF
--- a/apis/cluster/disposablerequest/v1alpha2/disposablerequest_types.go
+++ b/apis/cluster/disposablerequest/v1alpha2/disposablerequest_types.go
@@ -27,7 +27,7 @@ import (
 )
 
 // DisposableRequestParameters are the configurable fields of a DisposableRequest.
-// +kubebuilder:validation:XValidation:rule="!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))",message="insecureSkipTLSVerify and tlsConfig are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify && has(self.tlsConfig))",message="insecureSkipTLSVerify and tlsConfig are mutually exclusive"
 type DisposableRequestParameters struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Field 'forProvider.url' is immutable"
 	URL string `json:"url"`

--- a/apis/cluster/request/v1alpha2/request_types.go
+++ b/apis/cluster/request/v1alpha2/request_types.go
@@ -40,7 +40,7 @@ const (
 )
 
 // RequestParameters are the configurable fields of a Request.
-// +kubebuilder:validation:XValidation:rule="!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))",message="insecureSkipTLSVerify and tlsConfig are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify && has(self.tlsConfig))",message="insecureSkipTLSVerify and tlsConfig are mutually exclusive"
 type RequestParameters struct {
 	// Mappings defines the HTTP mappings for different methods.
 	// Either Method or Action must be specified. If both are omitted, the mapping will not be used.

--- a/apis/namespaced/disposablerequest/v1alpha2/disposablerequest_types.go
+++ b/apis/namespaced/disposablerequest/v1alpha2/disposablerequest_types.go
@@ -27,7 +27,7 @@ import (
 )
 
 // DisposableRequestParameters are the configurable fields of a DisposableRequest.
-// +kubebuilder:validation:XValidation:rule="!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))",message="insecureSkipTLSVerify and tlsConfig are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify && has(self.tlsConfig))",message="insecureSkipTLSVerify and tlsConfig are mutually exclusive"
 type DisposableRequestParameters struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Field 'forProvider.url' is immutable"
 	URL string `json:"url"`

--- a/apis/namespaced/request/v1alpha2/request_types.go
+++ b/apis/namespaced/request/v1alpha2/request_types.go
@@ -39,7 +39,7 @@ const (
 )
 
 // RequestParameters are the configurable fields of a Request.
-// +kubebuilder:validation:XValidation:rule="!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))",message="insecureSkipTLSVerify and tlsConfig are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify && has(self.tlsConfig))",message="insecureSkipTLSVerify and tlsConfig are mutually exclusive"
 type RequestParameters struct {
 	// Mappings defines the HTTP mappings for different methods.
 	// Either Method or Action must be specified. If both are omitted, the mapping will not be used.

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -41,6 +42,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/customresourcesgate"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
 
 	"github.com/crossplane-contrib/provider-http/apis"
 	httpcontrollers "github.com/crossplane-contrib/provider-http/internal/controller"
@@ -56,6 +59,7 @@ func main() {
 		pollInterval             = app.Flag("poll", "How often individual resources will be checked for drift from the desired state").Default("1m").Duration()
 		maxReconcileRate         = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
 		enableManagementPolicies = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
+		pollStateMetricInterval  = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
 
 		// namespace = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
 	)
@@ -91,6 +95,12 @@ func main() {
 	// Add CRD types to scheme for SafeStart capability
 	kingpin.FatalIfError(apiextensionsv1.AddToScheme(mgr.GetScheme()), "Cannot add CRD APIs to scheme")
 
+	metricRecorder := managed.NewMRMetricRecorder()
+	stateMetrics := statemetrics.NewMRStateMetrics()
+
+	metrics.Registry.MustRegister(metricRecorder)
+	metrics.Registry.MustRegister(stateMetrics)
+
 	o := controller.Options{
 		Logger:                  log,
 		MaxConcurrentReconciles: *maxReconcileRate,
@@ -98,6 +108,11 @@ func main() {
 		GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
 		Features:                &feature.Flags{},
 		Gate:                    new(gate.Gate[schema.GroupVersionKind]),
+		MetricOptions: &controller.MetricOptions{
+			PollStateMetricInterval: *pollStateMetricInterval,
+			MRMetrics:               metricRecorder,
+			MRStateMetrics:          stateMetrics,
+		},
 	}
 
 	// Enable management policies if flag is set

--- a/internal/clients/http/client.go
+++ b/internal/clients/http/client.go
@@ -33,7 +33,7 @@ type TLSConfigData struct {
 
 // Client is the interface to interact with Http
 type Client interface {
-	SendRequest(ctx context.Context, method string, url string, body Data, headers Data, tlsConfig *TLSConfigData) (resp HttpDetails, err error)
+	SendRequest(ctx context.Context, method string, url Data, body Data, headers Data, tlsConfig *TLSConfigData) (resp HttpDetails, err error)
 }
 
 type client struct {
@@ -89,15 +89,17 @@ type HttpDetails struct {
 }
 
 // SendRequest sends an HTTP request with optional TLS configuration.
-func (hc *client) SendRequest(ctx context.Context, method string, url string, body Data, headers Data, tlsConfigData *TLSConfigData) (details HttpDetails, err error) {
+func (hc *client) SendRequest(ctx context.Context, method string, url Data, body Data, headers Data, tlsConfigData *TLSConfigData) (details HttpDetails, err error) {
 	requestBody := []byte(body.Decrypted.(string))
 
 	// request contains the HTTP request that will be sent.
-	request, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(requestBody))
+	request, err := http.NewRequestWithContext(ctx, method, url.Decrypted.(string), bytes.NewBuffer(requestBody))
 
-	// requestDetails contains the request details that will be logged.
+	// requestDetails contains the request details that will be logged. URL uses the
+	// Encrypted (placeholder-preserved) form, same as Body/Headers, so a resolved
+	// secret value is never persisted to status or logs.
 	requestDetails := HttpRequest{
-		URL:     url,
+		URL:     url.Encrypted.(string),
 		Body:    body.Encrypted.(string),
 		Headers: headers.Encrypted.(map[string][]string),
 		Method:  method,

--- a/internal/clients/http/client_test.go
+++ b/internal/clients/http/client_test.go
@@ -549,7 +549,7 @@ func TestSendRequest(t *testing.T) {
 				t.Fatalf("NewClient(...): unexpected error: %v", err)
 			}
 
-			got, gotErr := c.SendRequest(context.Background(), tc.args.method, server.URL, tc.args.body, tc.args.headers, tc.args.tlsConfig)
+			got, gotErr := c.SendRequest(context.Background(), tc.args.method, Data{Encrypted: server.URL, Decrypted: server.URL}, tc.args.body, tc.args.headers, tc.args.tlsConfig)
 
 			if tc.want.err != nil || tc.want.errContains != "" {
 				if gotErr == nil {
@@ -611,7 +611,7 @@ func TestSendRequestIntegration(t *testing.T) {
 		result, err := c.SendRequest(
 			context.Background(),
 			http.MethodGet,
-			server.URL,
+			Data{Encrypted: server.URL, Decrypted: server.URL},
 			Data{Encrypted: "", Decrypted: ""},
 			Data{Encrypted: map[string][]string{}, Decrypted: map[string][]string{}},
 			tlsConfig,
@@ -972,7 +972,7 @@ func TestHTTPClientConfiguration(t *testing.T) {
 		_, err = c.SendRequest(
 			context.Background(),
 			http.MethodGet,
-			server.URL,
+			Data{Encrypted: server.URL, Decrypted: server.URL},
 			Data{Encrypted: "", Decrypted: ""},
 			Data{Encrypted: map[string][]string{}, Decrypted: map[string][]string{}},
 			&TLSConfigData{},
@@ -998,7 +998,7 @@ func TestHTTPClientConfiguration(t *testing.T) {
 		_, err = c.SendRequest(
 			context.Background(),
 			http.MethodGet,
-			server.URL,
+			Data{Encrypted: server.URL, Decrypted: server.URL},
 			Data{Encrypted: "", Decrypted: ""},
 			Data{Encrypted: map[string][]string{}, Decrypted: map[string][]string{}},
 			&TLSConfigData{},

--- a/internal/controller/cluster/disposablerequest/disposablerequest.go
+++ b/internal/controller/cluster/disposablerequest/disposablerequest.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 
 	"github.com/crossplane-contrib/provider-http/apis/cluster/disposablerequest/v1alpha2"
@@ -156,6 +157,15 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 
 	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOptions = append(reconcilerOptions, managed.WithManagementPolicies())
+	}
+
+	if o.MetricOptions != nil {
+		reconcilerOptions = append(reconcilerOptions, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
+
+		if err := mgr.Add(statemetrics.NewMRStateRecorder(
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha2.DisposableRequestList{}, o.MetricOptions.PollStateMetricInterval)); err != nil {
+			return err
+		}
 	}
 
 	r := managed.NewReconciler(mgr,

--- a/internal/controller/cluster/disposablerequest/disposablerequest_test.go
+++ b/internal/controller/cluster/disposablerequest/disposablerequest_test.go
@@ -99,20 +99,20 @@ func httpDisposableRequest(rm ...httpDisposableRequestModifier) *v1alpha2.Dispos
 	return r
 }
 
-type MockSendRequestFn func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestFn func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
-type MockSendRequestWithTLSFn func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestWithTLSFn func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
 type MockHttpClient struct {
 	MockSendRequest        MockSendRequestFn
 	MockSendRequestWithTLS MockSendRequestWithTLSFn
 }
 
-func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	return c.MockSendRequest(ctx, method, url, body, headers, tlsConfigData)
 }
 
-func (c *MockHttpClient) SendRequestWithTLS(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (c *MockHttpClient) SendRequestWithTLS(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	if c.MockSendRequestWithTLS != nil {
 		return c.MockSendRequestWithTLS(ctx, method, url, body, headers, tlsConfig)
 	}
@@ -153,7 +153,7 @@ func Test_httpExternal_Create(t *testing.T) {
 			name: "DisposableRequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -172,7 +172,7 @@ func Test_httpExternal_Create(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -233,7 +233,7 @@ func Test_httpExternal_Update(t *testing.T) {
 			name: "DisposableRequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -251,7 +251,7 @@ func Test_httpExternal_Update(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -508,7 +508,7 @@ func Test_deployAction(t *testing.T) {
 		"SuccessUpdateStatusRequestFailure": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errors.Errorf(utils.ErrInvalidURL, "invalid-url")
 					},
 				},
@@ -536,7 +536,7 @@ func Test_deployAction(t *testing.T) {
 		"SuccessUpdateStatusCodeError": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 400,
@@ -572,7 +572,7 @@ func Test_deployAction(t *testing.T) {
 		"SuccessUpdateStatusSuccessfulRequest": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -960,7 +960,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "TLSConfigAcceptedWithNilTLS",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the actual TLS config loading is handled by the service layer
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -984,7 +984,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "InsecureSkipTLSVerifyAccepted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the controller should handle insecure skip verify
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -1008,7 +1008,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "TLSConfigWithClientCertsAccepted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the service layer handles TLS config merging
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{

--- a/internal/controller/cluster/request/request.go
+++ b/internal/controller/cluster/request/request.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 
 	"github.com/crossplane-contrib/provider-http/apis/cluster/request/v1alpha2"
@@ -75,6 +76,15 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 
 	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOptions = append(reconcilerOptions, managed.WithManagementPolicies())
+	}
+
+	if o.MetricOptions != nil {
+		reconcilerOptions = append(reconcilerOptions, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
+
+		if err := mgr.Add(statemetrics.NewMRStateRecorder(
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha2.RequestList{}, o.MetricOptions.PollStateMetricInterval)); err != nil {
+			return err
+		}
 	}
 
 	r := managed.NewReconciler(mgr,

--- a/internal/controller/cluster/request/request_test.go
+++ b/internal/controller/cluster/request/request_test.go
@@ -104,20 +104,20 @@ type notHttpRequest struct {
 	resource.Managed
 }
 
-type MockSendRequestFn func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestFn func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
-type MockSendRequestWithTLSFn func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestWithTLSFn func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
 type MockHttpClient struct {
 	MockSendRequest        MockSendRequestFn
 	MockSendRequestWithTLS MockSendRequestWithTLSFn
 }
 
-func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	return c.MockSendRequest(ctx, method, url, body, headers, tlsConfigData)
 }
 
-func (c *MockHttpClient) SendRequestWithTLS(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (c *MockHttpClient) SendRequestWithTLS(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	if c.MockSendRequestWithTLS != nil {
 		return c.MockSendRequestWithTLS(ctx, method, url, body, headers, tlsConfig)
 	}
@@ -172,7 +172,7 @@ func Test_httpExternal_Create(t *testing.T) {
 			name: "RequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -190,7 +190,7 @@ func Test_httpExternal_Create(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -251,7 +251,7 @@ func Test_httpExternal_Update(t *testing.T) {
 			name: "RequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -269,7 +269,7 @@ func Test_httpExternal_Update(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -330,7 +330,7 @@ func Test_httpExternal_Delete(t *testing.T) {
 			name: "RequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -348,7 +348,7 @@ func Test_httpExternal_Delete(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -410,7 +410,7 @@ func Test_httpExternal_Observe(t *testing.T) {
 			name: "ResourceUpToDate",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -846,7 +846,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "TLSConfigAcceptedWithNilTLS",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the actual TLS config loading is handled by the service layer
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -870,7 +870,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "InsecureSkipTLSVerifyAccepted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the controller should handle insecure skip verify
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -894,7 +894,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "TLSConfigWithClientCertsAccepted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the service layer handles TLS config merging
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -1003,7 +1003,7 @@ func TestObserve_DeletionMonitoring(t *testing.T) {
 			name: "ResourceBeingDeleted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,

--- a/internal/controller/namespaced/disposablerequest/disposablerequest.go
+++ b/internal/controller/namespaced/disposablerequest/disposablerequest.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 
 	"github.com/crossplane-contrib/provider-http/apis/common"
@@ -158,6 +159,15 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 
 	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOptions = append(reconcilerOptions, managed.WithManagementPolicies())
+	}
+
+	if o.MetricOptions != nil {
+		reconcilerOptions = append(reconcilerOptions, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
+
+		if err := mgr.Add(statemetrics.NewMRStateRecorder(
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha2.DisposableRequestList{}, o.MetricOptions.PollStateMetricInterval)); err != nil {
+			return err
+		}
 	}
 
 	r := managed.NewReconciler(mgr,

--- a/internal/controller/namespaced/disposablerequest/disposablerequest_test.go
+++ b/internal/controller/namespaced/disposablerequest/disposablerequest_test.go
@@ -67,20 +67,20 @@ const (
 	testBody   = "{\"key1\": \"value1\"}"
 )
 
-type MockSendRequestFn func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestFn func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
-type MockSendRequestWithTLSFn func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestWithTLSFn func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
 type MockHttpClient struct {
 	MockSendRequest        MockSendRequestFn
 	MockSendRequestWithTLS MockSendRequestWithTLSFn
 }
 
-func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	return c.MockSendRequest(ctx, method, url, body, headers, tlsConfigData)
 }
 
-func (c *MockHttpClient) SendRequestWithTLS(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (c *MockHttpClient) SendRequestWithTLS(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	if c.MockSendRequestWithTLS != nil {
 		return c.MockSendRequestWithTLS(ctx, method, url, body, headers, tlsConfig)
 	}
@@ -315,7 +315,7 @@ func TestCreate(t *testing.T) {
 			name: "HttpRequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -333,7 +333,7 @@ func TestCreate(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -398,7 +398,7 @@ func TestUpdate(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -497,7 +497,7 @@ func Test_deployAction(t *testing.T) {
 		"SuccessUpdateStatusRequestFailure": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errors.Errorf(utils.ErrInvalidURL, "invalid-url")
 					},
 				},
@@ -525,7 +525,7 @@ func Test_deployAction(t *testing.T) {
 		"SuccessUpdateStatusCodeError": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 400,
@@ -561,7 +561,7 @@ func Test_deployAction(t *testing.T) {
 		"SuccessUpdateStatusSuccessfulRequest": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -982,7 +982,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "TLSConfigAcceptedWithNilTLS",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the actual TLS config loading is handled by the service layer
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -1006,7 +1006,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "InsecureSkipTLSVerifyAccepted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the controller should handle insecure skip verify
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -1030,7 +1030,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "TLSConfigWithClientCertsAccepted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the service layer handles TLS config merging
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{

--- a/internal/controller/namespaced/request/request.go
+++ b/internal/controller/namespaced/request/request.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 
 	"github.com/crossplane-contrib/provider-http/apis/common"
@@ -77,6 +78,15 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 
 	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOptions = append(reconcilerOptions, managed.WithManagementPolicies())
+	}
+
+	if o.MetricOptions != nil {
+		reconcilerOptions = append(reconcilerOptions, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
+
+		if err := mgr.Add(statemetrics.NewMRStateRecorder(
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1alpha2.RequestList{}, o.MetricOptions.PollStateMetricInterval)); err != nil {
+			return err
+		}
 	}
 
 	r := managed.NewReconciler(mgr,

--- a/internal/controller/namespaced/request/request_test.go
+++ b/internal/controller/namespaced/request/request_test.go
@@ -69,20 +69,20 @@ var (
 	}
 )
 
-type MockSendRequestFn func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestFn func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
-type MockSendRequestWithTLSFn func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestWithTLSFn func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
 type MockHttpClient struct {
 	MockSendRequest        MockSendRequestFn
 	MockSendRequestWithTLS MockSendRequestWithTLSFn
 }
 
-func (m *MockHttpClient) SendRequest(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (m *MockHttpClient) SendRequest(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	return m.MockSendRequest(ctx, method, url, body, headers, tlsConfigData)
 }
 
-func (m *MockHttpClient) SendRequestWithTLS(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (m *MockHttpClient) SendRequestWithTLS(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfig *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	if m.MockSendRequestWithTLS != nil {
 		return m.MockSendRequestWithTLS(ctx, method, url, body, headers, tlsConfig)
 	}
@@ -192,7 +192,7 @@ func TestObserve(t *testing.T) {
 			name: "ResourceBeingDeleted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errors.New("resource not found")
 					},
 				},
@@ -257,7 +257,7 @@ func TestCreate(t *testing.T) {
 			name: "RequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -275,7 +275,7 @@ func TestCreate(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -336,7 +336,7 @@ func TestUpdate(t *testing.T) {
 			name: "RequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -354,7 +354,7 @@ func TestUpdate(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -415,7 +415,7 @@ func TestDelete(t *testing.T) {
 			name: "RequestFailed",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -433,7 +433,7 @@ func TestDelete(t *testing.T) {
 			name: "Success",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -834,7 +834,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "TLSConfigAcceptedWithNilTLS",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the actual TLS config loading is handled by the service layer
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -858,7 +858,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "InsecureSkipTLSVerifyAccepted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the controller should handle insecure skip verify
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -882,7 +882,7 @@ func TestTLSConfiguration(t *testing.T) {
 			name: "TLSConfigWithClientCertsAccepted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						// Accept any TLS config - the service layer handles TLS config merging
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
@@ -991,7 +991,7 @@ func TestObserve_DeletionMonitoring(t *testing.T) {
 			name: "ResourceBeingDeleted",
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,

--- a/internal/service/disposablerequest/deployaction.go
+++ b/internal/service/disposablerequest/deployaction.go
@@ -53,6 +53,11 @@ func DeployAction(svcCtx *service.ServiceContext, crCtx *service.DisposableReque
 
 // sendHttpRequest sends the HTTP request with sensitive data patched
 func sendHttpRequest(svcCtx *service.ServiceContext, spec interfaces.SimpleHTTPRequestSpec) (httpClient.HttpDetails, error) {
+	sensitiveURL, err := datapatcher.PatchSecretsIntoString(svcCtx.Ctx, svcCtx.LocalKube, spec.GetURL(), svcCtx.Logger)
+	if err != nil {
+		return httpClient.HttpDetails{}, err
+	}
+
 	sensitiveBody, err := datapatcher.PatchSecretsIntoString(svcCtx.Ctx, svcCtx.LocalKube, spec.GetBody(), svcCtx.Logger)
 	if err != nil {
 		return httpClient.HttpDetails{}, err
@@ -63,9 +68,10 @@ func sendHttpRequest(svcCtx *service.ServiceContext, spec interfaces.SimpleHTTPR
 		return httpClient.HttpDetails{}, err
 	}
 
+	urlData := httpClient.Data{Encrypted: spec.GetURL(), Decrypted: sensitiveURL}
 	bodyData := httpClient.Data{Encrypted: spec.GetBody(), Decrypted: sensitiveBody}
 	headersData := httpClient.Data{Encrypted: spec.GetHeaders(), Decrypted: sensitiveHeaders}
-	details, err := svcCtx.HTTP.SendRequest(svcCtx.Ctx, spec.GetMethod(), spec.GetURL(), bodyData, headersData, svcCtx.TLSConfigData)
+	details, err := svcCtx.HTTP.SendRequest(svcCtx.Ctx, spec.GetMethod(), urlData, bodyData, headersData, svcCtx.TLSConfigData)
 
 	return details, err
 }

--- a/internal/service/disposablerequest/deployaction_test.go
+++ b/internal/service/disposablerequest/deployaction_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -23,13 +24,13 @@ const (
 	testBody           = `{"username": "john_doe"}`
 )
 
-type MockSendRequestFn func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestFn func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
 type MockHttpClient struct {
 	MockSendRequest MockSendRequestFn
 }
 
-func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	return c.MockSendRequest(ctx, method, url, body, headers, tlsConfigData)
 }
 
@@ -112,7 +113,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -167,7 +168,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -192,7 +193,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 500,
@@ -230,7 +231,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -278,7 +279,7 @@ func TestDeployAction(t *testing.T) {
 					}),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -315,7 +316,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 201,
@@ -393,7 +394,7 @@ func TestSendHttpRequest(t *testing.T) {
 				},
 				localKube: &test.MockClient{},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -419,7 +420,7 @@ func TestSendHttpRequest(t *testing.T) {
 				},
 				localKube: &test.MockClient{},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -452,6 +453,52 @@ func TestSendHttpRequest(t *testing.T) {
 				t.Errorf("\n%s\nsendHttpRequest(...): wanted status code %d, got %d", tc.reason, tc.want.statusCode, details.HttpResponse.StatusCode)
 			}
 		})
+	}
+}
+
+// TestSendHttpRequest_ResolvesSecretsInURL is a regression test: sendHttpRequest
+// must resolve {{ name:namespace:key }} placeholders in the URL, the same way it
+// already does for Body and Headers, and must never pass the resolved secret
+// value as the Encrypted (status/logged) form.
+func TestSendHttpRequest_ResolvesSecretsInURL(t *testing.T) {
+	var gotURL httpClient.Data
+
+	spec := &v1alpha2.DisposableRequestParameters{
+		URL:    "https://api.example.com/users?token={{ my-secret:my-namespace:token }}",
+		Method: "GET",
+	}
+
+	localKube := &test.MockClient{
+		MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok {
+				return errors.New("object is not a Secret")
+			}
+			secret.Data = map[string][]byte{"token": []byte("real-token-value")}
+			return nil
+		},
+	}
+
+	mockHTTP := &MockHttpClient{
+		MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+			gotURL = url
+			return httpClient.HttpDetails{HttpResponse: httpClient.HttpResponse{StatusCode: 200}}, nil
+		},
+	}
+
+	svcCtx := service.NewServiceContext(context.Background(), localKube, logging.NewNopLogger(), mockHTTP, nil)
+	if _, err := sendHttpRequest(svcCtx, spec); err != nil {
+		t.Fatalf("sendHttpRequest(...): unexpected error: %v", err)
+	}
+
+	wantEncrypted := "https://api.example.com/users?token={{ my-secret:my-namespace:token }}"
+	wantDecrypted := "https://api.example.com/users?token=real-token-value"
+
+	if gotURL.Encrypted != wantEncrypted {
+		t.Errorf("sendHttpRequest(...): url.Encrypted = %q, want %q", gotURL.Encrypted, wantEncrypted)
+	}
+	if gotURL.Decrypted != wantDecrypted {
+		t.Errorf("sendHttpRequest(...): url.Decrypted = %q, want %q", gotURL.Decrypted, wantDecrypted)
 	}
 }
 

--- a/internal/service/request/deployaction_test.go
+++ b/internal/service/request/deployaction_test.go
@@ -81,7 +81,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 201,
@@ -132,7 +132,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -184,7 +184,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 200,
@@ -235,7 +235,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								StatusCode: 204,
@@ -286,7 +286,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, errBoom
 					},
 				},
@@ -322,7 +322,7 @@ func TestDeployAction(t *testing.T) {
 					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
 				},
 				httpClient: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},

--- a/internal/service/request/observe_test.go
+++ b/internal/service/request/observe_test.go
@@ -95,13 +95,13 @@ func httpRequest(rm ...httpRequestModifier) *v1alpha2.Request {
 	return r
 }
 
-type MockSendRequestFn func(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
+type MockSendRequestFn func(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error)
 
 type MockHttpClient struct {
 	MockSendRequest MockSendRequestFn
 }
 
-func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url string, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+func (c *MockHttpClient) SendRequest(ctx context.Context, method string, url httpClient.Data, body httpClient.Data, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 	return c.MockSendRequest(ctx, method, url, body, headers, tlsConfigData)
 }
 
@@ -123,7 +123,7 @@ func Test_isUpToDate(t *testing.T) {
 		"ObjectIdKnownBeforeCreate": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								Body:       `{"username":"john_doe_new_username"}`,
@@ -160,7 +160,7 @@ func Test_isUpToDate(t *testing.T) {
 		"ObjectNotFoundEmptyStatus": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -179,7 +179,7 @@ func Test_isUpToDate(t *testing.T) {
 		"ObjectNotFoundPostFailed": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -198,7 +198,7 @@ func Test_isUpToDate(t *testing.T) {
 		"ObjectNotFound404StatusCode": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								Body:       "",
@@ -221,7 +221,7 @@ func Test_isUpToDate(t *testing.T) {
 		"FailBodyNotJSON": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								Body: "not a JSON",
@@ -244,7 +244,7 @@ func Test_isUpToDate(t *testing.T) {
 		"SuccessNotSynced": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								Body:       `{"username":"old_name"}`,
@@ -279,7 +279,7 @@ func Test_isUpToDate(t *testing.T) {
 		"SuccessNoPUTMapping": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								Body:       `{"username":"old_name"}`,
@@ -319,7 +319,7 @@ func Test_isUpToDate(t *testing.T) {
 		"SuccessJSONBody": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{
 							HttpResponse: httpClient.HttpResponse{
 								Body:       `{"username":"john_doe_new_username"}`,
@@ -354,7 +354,7 @@ func Test_isUpToDate(t *testing.T) {
 		"MissingMappingObjectNotCreated": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -379,7 +379,7 @@ func Test_isUpToDate(t *testing.T) {
 		"MissingMappingObjectCreated": {
 			args: args{
 				http: &MockHttpClient{
-					MockSendRequest: func(ctx context.Context, method string, url string, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
+					MockSendRequest: func(ctx context.Context, method string, url httpClient.Data, body, headers httpClient.Data, tlsConfigData *httpClient.TLSConfigData) (resp httpClient.HttpDetails, err error) {
 						return httpClient.HttpDetails{}, nil
 					},
 				},
@@ -745,7 +745,10 @@ func Test_requestDetails(t *testing.T) {
 			},
 			want: want{
 				result: requestgen.RequestDetails{
-					Url: "https://api.example.com/users/",
+					Url: httpClient.Data{
+						Encrypted: "https://api.example.com/users/",
+						Decrypted: "https://api.example.com/users/",
+					},
 					Body: httpClient.Data{
 						Encrypted: "",
 						Decrypted: "",
@@ -777,7 +780,10 @@ func Test_requestDetails(t *testing.T) {
 			},
 			want: want{
 				result: requestgen.RequestDetails{
-					Url: "https://api.example.com/users",
+					Url: httpClient.Data{
+						Encrypted: "https://api.example.com/users",
+						Decrypted: "https://api.example.com/users",
+					},
 					Body: httpClient.Data{
 						Encrypted: `{"email":"john.doe@example.com","username":"john_doe"}`,
 						Decrypted: `{"email":"john.doe@example.com","username":"john_doe"}`,

--- a/internal/service/request/requestgen/request_generator.go
+++ b/internal/service/request/requestgen/request_generator.go
@@ -16,7 +16,7 @@ import (
 )
 
 type RequestDetails struct {
-	Url     string
+	Url     httpClient.Data
 	Body    httpClient.Data
 	Headers httpClient.Data
 }
@@ -29,13 +29,13 @@ func GenerateRequestDetails(svcCtx *service.ServiceContext, methodMapping interf
 	}
 
 	jqObject := GenerateRequestContext(forProvider, patchedResponse)
-	url, err := generateURL(methodMapping.GetURL(), jqObject)
+	url, err := generateURL(svcCtx, methodMapping.GetURL(), jqObject)
 	if err != nil {
 		return RequestDetails{}, err, false
 	}
 
-	if !utils.IsUrlValid(url) {
-		return RequestDetails{}, errors.Errorf(utils.ErrInvalidURL, url), false
+	if !utils.IsUrlValid(url.Decrypted.(string)) {
+		return RequestDetails{}, errors.Errorf(utils.ErrInvalidURL, url.Decrypted.(string)), false
 	}
 
 	body, err := generateBody(svcCtx, methodMapping.GetBody(), jqObject)
@@ -96,7 +96,8 @@ func GenerateValidRequestDetails(svcCtx *service.ServiceContext, crCtx *service.
 
 // IsRequestValid checks if the request details are valid.
 func IsRequestValid(requestDetails RequestDetails) bool {
-	return (!strings.Contains(fmt.Sprint(requestDetails), "null")) && (requestDetails.Url != "")
+	url, ok := requestDetails.Url.Decrypted.(string)
+	return (!strings.Contains(fmt.Sprint(requestDetails), "null")) && ok && (url != "")
 }
 
 // coalesceHeaders returns the non-nil headers, or the default headers if both are nil.
@@ -107,14 +108,23 @@ func coalesceHeaders(mapping interfaces.HTTPMapping, spec interfaces.HTTPRequest
 	return spec.GetHeaders()
 }
 
-// generateURL applies a JQ filter to generate a URL.
-func generateURL(urlJQFilter string, jqObject map[string]interface{}) (string, error) {
+// generateURL applies a JQ filter to generate a URL, then resolves any
+// secret placeholders in it the same way generateBody/generateHeaders do.
+func generateURL(svcCtx *service.ServiceContext, urlJQFilter string, jqObject map[string]interface{}) (httpClient.Data, error) {
 	getURL, err := requestprocessing.ApplyJQOnStr(urlJQFilter, jqObject)
 	if err != nil {
-		return "", err
+		return httpClient.Data{}, err
 	}
 
-	return getURL, nil
+	sensitiveURL, err := datapatcher.PatchSecretsIntoString(svcCtx.Ctx, svcCtx.LocalKube, getURL, svcCtx.Logger)
+	if err != nil {
+		return httpClient.Data{}, err
+	}
+
+	return httpClient.Data{
+		Encrypted: getURL,
+		Decrypted: sensitiveURL,
+	}, nil
 }
 
 // generateBody applies a mapping body to generate the request body.

--- a/internal/service/request/requestgen/request_generator_test.go
+++ b/internal/service/request/requestgen/request_generator_test.go
@@ -8,6 +8,8 @@ import (
 	httpClient "github.com/crossplane-contrib/provider-http/internal/clients/http"
 	"github.com/crossplane-contrib/provider-http/internal/service"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
@@ -100,7 +102,10 @@ func Test_GenerateRequestDetails(t *testing.T) {
 			},
 			want: want{
 				requestDetails: RequestDetails{
-					Url: "https://api.example.com/users",
+					Url: httpClient.Data{
+						Encrypted: "https://api.example.com/users",
+						Decrypted: "https://api.example.com/users",
+					},
 					Body: httpClient.Data{
 						Encrypted: `{"email":"john.doe@example.com","username":"john_doe"}`,
 						Decrypted: `{"email":"john.doe@example.com","username":"john_doe"}`,
@@ -127,7 +132,10 @@ func Test_GenerateRequestDetails(t *testing.T) {
 			},
 			want: want{
 				requestDetails: RequestDetails{
-					Url: "https://api.example.com/users/123",
+					Url: httpClient.Data{
+						Encrypted: "https://api.example.com/users/123",
+						Decrypted: "https://api.example.com/users/123",
+					},
 					Body: httpClient.Data{
 						Encrypted: `{"username":"john_doe_new_username"}`,
 						Decrypted: `{"username":"john_doe_new_username"}`,
@@ -154,7 +162,10 @@ func Test_GenerateRequestDetails(t *testing.T) {
 			},
 			want: want{
 				requestDetails: RequestDetails{
-					Url: "https://api.example.com/users/123",
+					Url: httpClient.Data{
+						Encrypted: "https://api.example.com/users/123",
+						Decrypted: "https://api.example.com/users/123",
+					},
 					Headers: httpClient.Data{
 						Decrypted: map[string][]string{},
 						Encrypted: map[string][]string{},
@@ -181,7 +192,52 @@ func Test_GenerateRequestDetails(t *testing.T) {
 			},
 			want: want{
 				requestDetails: RequestDetails{
-					Url: "https://api.example.com/users/123",
+					Url: httpClient.Data{
+						Encrypted: "https://api.example.com/users/123",
+						Decrypted: "https://api.example.com/users/123",
+					},
+					Headers: httpClient.Data{
+						Decrypted: map[string][]string{},
+						Encrypted: map[string][]string{},
+					},
+					Body: httpClient.Data{
+						Decrypted: "",
+						Encrypted: "",
+					},
+				},
+				err: nil,
+				ok:  true,
+			},
+		},
+		"SuccessGetWithSecretInURL": {
+			// Regression test: generateURL must resolve {{ name:namespace:key }}
+			// placeholders the same way generateBody/generateHeaders do, so a
+			// secret-backed value can be used inside a mapping's URL.
+			args: args{
+				methodMapping: v1alpha2.Mapping{
+					Method: "GET",
+					URL:    `("https://api.example.com/users?token={{ my-secret:my-namespace:token }}")`,
+				},
+				forProvider: testForProvider,
+				response:    v1alpha2.Response{},
+				logger:      logging.NewNopLogger(),
+				localKube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+						secret, ok := obj.(*corev1.Secret)
+						if !ok {
+							return errors.New("object is not a Secret")
+						}
+						secret.Data = map[string][]byte{"token": []byte("real-token-value")}
+						return nil
+					},
+				},
+			},
+			want: want{
+				requestDetails: RequestDetails{
+					Url: httpClient.Data{
+						Encrypted: "https://api.example.com/users?token={{ my-secret:my-namespace:token }}",
+						Decrypted: "https://api.example.com/users?token=real-token-value",
+					},
 					Headers: httpClient.Data{
 						Decrypted: map[string][]string{},
 						Encrypted: map[string][]string{},
@@ -238,7 +294,10 @@ func Test_IsRequestValid(t *testing.T) {
 						Decrypted: nil,
 						Encrypted: nil,
 					},
-					Url: "https://example",
+					Url: httpClient.Data{
+						Encrypted: "https://example",
+						Decrypted: "https://example",
+					},
 				},
 			},
 			want: want{
@@ -256,7 +315,10 @@ func Test_IsRequestValid(t *testing.T) {
 						Decrypted: nil,
 						Encrypted: nil,
 					},
-					Url: "",
+					Url: httpClient.Data{
+						Encrypted: "",
+						Decrypted: "",
+					},
 				},
 			},
 			want: want{
@@ -274,7 +336,10 @@ func Test_IsRequestValid(t *testing.T) {
 						Decrypted: nil,
 						Encrypted: nil,
 					},
-					Url: "",
+					Url: httpClient.Data{
+						Encrypted: "",
+						Decrypted: "",
+					},
 				},
 			},
 			want: want{
@@ -292,7 +357,10 @@ func Test_IsRequestValid(t *testing.T) {
 						Decrypted: nil,
 						Encrypted: nil,
 					},
-					Url: "https://example",
+					Url: httpClient.Data{
+						Encrypted: "https://example",
+						Decrypted: "https://example",
+					},
 				},
 			},
 			want: want{

--- a/package/crds/http.crossplane.io_disposablerequests.yaml
+++ b/package/crds/http.crossplane.io_disposablerequests.yaml
@@ -613,7 +613,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: insecureSkipTLSVerify and tlsConfig are mutually exclusive
-                  rule: '!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))'
+                  rule: '!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify
+                    && has(self.tlsConfig))'
               managementPolicies:
                 default:
                 - '*'

--- a/package/crds/http.crossplane.io_requests.yaml
+++ b/package/crds/http.crossplane.io_requests.yaml
@@ -688,7 +688,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: insecureSkipTLSVerify and tlsConfig are mutually exclusive
-                  rule: '!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))'
+                  rule: '!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify
+                    && has(self.tlsConfig))'
               managementPolicies:
                 default:
                 - '*'

--- a/package/crds/http.m.crossplane.io_disposablerequests.yaml
+++ b/package/crds/http.m.crossplane.io_disposablerequests.yaml
@@ -294,7 +294,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: insecureSkipTLSVerify and tlsConfig are mutually exclusive
-                  rule: '!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))'
+                  rule: '!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify
+                    && has(self.tlsConfig))'
               managementPolicies:
                 default:
                 - '*'

--- a/package/crds/http.m.crossplane.io_requests.yaml
+++ b/package/crds/http.m.crossplane.io_requests.yaml
@@ -344,7 +344,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: insecureSkipTLSVerify and tlsConfig are mutually exclusive
-                  rule: '!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))'
+                  rule: '!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify
+                    && has(self.tlsConfig))'
               managementPolicies:
                 default:
                 - '*'


### PR DESCRIPTION
## Summary

Three independent fixes/features, kept in one PR since they're small and each was quick to review on its own. Happy to split into separate PRs if preferred.

### #186 — URL secret placeholders never resolved
`generateURL()` (Request kind) and `sendHttpRequest()` (DisposableRequest) never ran the URL through `datapatcher.PatchSecretsIntoString`, unlike Body/Headers. A `{{ name:namespace:key }}` placeholder in a mapping's URL was sent to the server literally unresolved, typically breaking request framing.

The fix isn't just "call the patcher" — `RequestDetails.Url` and `Client.SendRequest`'s `url` param change from a plain `string` to `httpClient.Data` (Encrypted/Decrypted), matching the existing Body/Headers pattern. This matters: naively returning the resolved URL as a single string would leak the resolved secret value into the CR's own `status.requestDetails.url`. Encrypted (placeholder-preserved) goes to status/logs; Decrypted (secret-resolved) is what's actually sent — exactly like Body/Headers already work.

Added regression tests for both Request and DisposableRequest proving the secret actually resolves and the encrypted/status form still hides it.

### #164 — CRD validation rejects valid `tlsConfig` requests
The CEL rule `!(self.insecureSkipTLSVerify == true && has(self.tlsConfig))` references `self.insecureSkipTLSVerify` without a `has()` guard. Since that field is optional with no CRD-level default, submitting `tlsConfig` without also explicitly setting `insecureSkipTLSVerify` fails CEL evaluation outright with `no such key: insecureSkipTLSVerify` — rejecting the exact valid request from the issue.

Fixed to `!(has(self.insecureSkipTLSVerify) && self.insecureSkipTLSVerify && has(self.tlsConfig))` across all 4 affected types (cluster/namespaced × Request/DisposableRequest). CRDs regenerated via the project's own `go:generate` (`controller-gen`) — diff is isolated to the 4 changed rules.

### #140 — Expose crossplane-runtime MR metrics
Wires up `managed.NewMRMetricRecorder()` and `statemetrics.NewMRStateMetrics()` per the [crossplane metrics guide](https://docs.crossplane.io/latest/guides/metrics/), following the same pattern as `provider-template`'s own metrics PR (crossplane/provider-template#106) linked in the issue. Adds `--poll-state-metric` (default `5s`). Each of the 4 per-kind `Setup` functions gets `managed.WithMetricRecorder` plus a `statemetrics.MRStateRecorder` runnable scoped to its own List type, guarded on `MetricOptions != nil` so `Setup` stays safe to call without metrics configured (e.g. from tests).

## Test plan
- [x] `go build ./...` and `go vet ./...` — full repo
- [x] `go test ./...` — all pass, including new regression tests for #186 (`internal/service/request/requestgen`, `internal/service/disposablerequest`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt -l` — clean
- [x] CRDs regenerated via `go:generate` (controller-gen v0.20.0, matching go.mod's tool pin) — diff isolated to the #164 rule change