### PR TITLE
docs: document read-only/polling mode for Request

### DIFF
--- a/internal/service/request/observe_test.go
+++ b/internal/service/request/observe_test.go
@@ -373,7 +373,7 @@ func Test_isUpToDate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.New("OBSERVE or GET mapping doesn't exist in request, skipping operation"),
+				err: errors.Errorf(requestmapping.ErrMappingNotFound, "OBSERVE", http.MethodGet),
 			},
 		},
 		"MissingMappingObjectCreated": {
@@ -399,7 +399,7 @@ func Test_isUpToDate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.New("OBSERVE or GET mapping doesn't exist in request, skipping operation"),
+				err: errors.Errorf(requestmapping.ErrMappingNotFound, "OBSERVE", http.MethodGet),
 			},
 		},
 	}

--- a/internal/service/request/requestmapping/mapping.go
+++ b/internal/service/request/requestmapping/mapping.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	ErrMappingNotFound = "%s or %s mapping doesn't exist in request, skipping operation"
+	ErrMappingNotFound = "no %s mapping defined for method %s - skipping this operation (expected for read-only Requests that only define an OBSERVE mapping)"
 )
 
 var (

--- a/resources-docs/request_docs.md
+++ b/resources-docs/request_docs.md
@@ -52,6 +52,37 @@ Here is an example `Request` resource definition:
 ### Secrets Injection
 The DisposableRequest resource supports injecting data from secrets into the request's body and headers using the following syntax: {{ name:namespace:key }} (supported for body and headers only).
 
+### Read-Only / Polling Mode
+A `Request` doesn't require a mapping for every action. If a mapping isn't found for CREATE, UPDATE, or REMOVE, the provider logs it and skips that action - it's not treated as an error. Defining only an OBSERVE (GET) mapping therefore turns a `Request` into a periodic, read-only poller: on every reconcile it issues the GET, and - combined with `secretInjectionConfigs` - can extract fields from the response into a Secret without ever attempting to create, update, or delete anything.
+
+This is useful for syncing data from an existing endpoint you don't manage the lifecycle of - for example, mirroring a value from an external API into a Secret so other resources can reference it.
+
+  ```yaml
+  apiVersion: http.crossplane.io/v1alpha2
+  kind: Request
+  metadata:
+    name: sync-external-status
+  spec:
+    forProvider:
+      headers:
+        Authorization:
+          - "Bearer {{ auth:default:token }}"
+      payload:
+        baseUrl: "https://api.example.com/v1/status"
+      mappings:
+        # Only an OBSERVE mapping - no CREATE, UPDATE, or REMOVE, so this
+        # Request never attempts to modify anything at the remote endpoint.
+        - action: OBSERVE
+          url: .payload.baseUrl
+      secretInjectionConfigs:
+        - secretRef:
+            name: external-status
+            namespace: default
+          keyMappings:
+            - secretKey: status
+              responseJQ: .body.status
+  ```
+
 ## PUT Mapping - Desired State
 The PUT mapping represents your desired state. The body in this mapping should be contained in the GET response. If it's not, a PUT request will be sent with the according body.
 


### PR DESCRIPTION
## Summary

While reviewing the codebase (context: worked on #186/#164/#140 in #189), I noticed `Request` already supports a read-only, poll-and-sync-to-secret pattern that isn't documented anywhere.

`DeployAction` (`internal/service/request/deployaction.go:14-19`) silently no-ops when `requestmapping.GetMapping` finds no mapping for CREATE/UPDATE/REMOVE - it logs and returns `nil`, not an error. So a `Request` defining **only an OBSERVE mapping** never attempts to create, update, or delete anything - it just polls on the normal reconcile interval and, combined with `secretInjectionConfigs`, can extract fields from the response into a Secret.

That's a genuinely useful pattern (sync an external API's data into a Secret without modeling a full CRUD lifecycle you don't own), but nothing in `resources-docs/` or `examples/` shows it - every existing example defines full CRUD mappings. This PR just makes the existing capability discoverable:

- `resources-docs/request_docs.md`: new "Read-Only / Polling Mode" section with an inline example, placed next to the existing "Secrets Injection" section it builds on.
- `requestmapping.ErrMappingNotFound` reworded from `"%s or %s mapping doesn't exist in request, skipping operation"` to explicitly frame this as expected/intentional for read-only Requests, not a misconfiguration warning someone might see in logs and worry about.

No behavior change - the reworded string is referenced everywhere via the `ErrMappingNotFound` constant (including a programmatic equality check in `is_synced_check.go`'s `isErrorMappingNotFound`), not duplicated as a literal, so every caller picks up the new wording automatically. One test asserted against the old literal string directly instead of the constant - fixed to reference the constant like the others do.

## Test plan
- [x] `go build ./...`, `go vet ./...` - full repo
- [x] `go test ./...` - all pass
- [x] `golangci-lint run ./...` - 0 issues
- [x] `gofmt -l` - clean

Didn't add a new file under `examples/sample/` - that directory is picked up by `UPTEST_EXAMPLE_LIST` in the Makefile and run against the live e2e test-server (`cluster/test`), whose in-memory user store isn't pre-seeded, so a standalone read-only example there would need a companion resource just to have something to observe. Kept the example inline in the docs instead, matching how the rest of `request_docs.md` already illustrates behavior with inline YAML rather than separate files.